### PR TITLE
Upgrade to Java 25, add Lombok + SLF4J/Logback, update Maven plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,15 +8,19 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.release>25</maven.compiler.release>
 
         <!-- Third-party -->
         <commons-text.version>1.15.0</commons-text.version>
         <jackson-databind.version>2.19.0</jackson-databind.version>
+        <logback-classic.version>1.5.18</logback-classic.version>
+        <lombok.version>1.18.38</lombok.version>
+        <slf4j-api.version>2.0.17</slf4j-api.version>
 
         <!-- Plugins -->
-        <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
-        <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
+        <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
+        <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
+        <maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
     </properties>
 
@@ -32,6 +36,23 @@
             <version>${jackson-databind.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback-classic.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.12.2</version>
@@ -41,6 +62,22 @@
 
     <build>
         <plugins>
+            <!-- Needed to compile with Lombok annotation processor. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+
             <!-- Needed to run JUnit 5 tests. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>nyg/renovate-presets"
+  ]
+}

--- a/src/main/java/edu/self/w2k/CLI.java
+++ b/src/main/java/edu/self/w2k/CLI.java
@@ -1,41 +1,32 @@
 package edu.self.w2k;
 
-import java.util.logging.Logger;
-
 import edu.self.w2k.util.DumpUtil;
 import edu.self.w2k.util.WiktionaryUtil;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class CLI {
-
-    private static final Logger LOG = Logger.getLogger(CLI.class.getName());
 
     public static void main(String[] args) {
 
         if (args == null || args.length == 0) {
-            LOG.severe("Arguments required!");
+            log.error("No arguments provided. Usage: <action> [lang]  (actions: download, generate)");
             return;
         }
 
         String action = args[0];
-        String lang = "en";
+        String lang = args.length > 1 ? args[1] : "en";
 
-        try {
-            lang = args[1];
-        }
-        catch (ArrayIndexOutOfBoundsException e) {
-            // nothing
-        }
+        log.info("Running: action={}, lang={}", action, lang);
 
-        LOG.info(String.format("Executing: %s %s", action, lang));
-
-        // download
         if (action.matches("dl|download")) {
             DumpUtil.download();
         }
-
-        // generate [lang]
-        if (action.equals("generate")) {
+        else if (action.equals("generate")) {
             WiktionaryUtil.generateDictionary(lang);
+        }
+        else {
+            log.error("Unknown action '{}'. Usage: <action> [lang]  (actions: download, generate)", action);
         }
     }
 }

--- a/src/main/java/edu/self/w2k/model/WiktionaryEntry.java
+++ b/src/main/java/edu/self/w2k/model/WiktionaryEntry.java
@@ -2,9 +2,11 @@ package edu.self.w2k.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
 
 import java.util.List;
 
+@Getter
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class WiktionaryEntry {
 
@@ -14,14 +16,6 @@ public class WiktionaryEntry {
     private String langCode;
 
     private List<WiktionarySense> senses;
-
-    public String getWord() {
-        return word;
-    }
-
-    public String getLangCode() {
-        return langCode;
-    }
 
     public List<WiktionarySense> getSenses() {
         return senses != null ? senses : List.of();

--- a/src/main/java/edu/self/w2k/model/WiktionaryExample.java
+++ b/src/main/java/edu/self/w2k/model/WiktionaryExample.java
@@ -1,13 +1,11 @@
 package edu.self.w2k.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
 
+@Getter
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class WiktionaryExample {
 
     private String text;
-
-    public String getText() {
-        return text;
-    }
 }

--- a/src/main/java/edu/self/w2k/model/WiktionarySense.java
+++ b/src/main/java/edu/self/w2k/model/WiktionarySense.java
@@ -1,9 +1,11 @@
 package edu.self.w2k.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
 
 import java.util.List;
 
+@Getter
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class WiktionarySense {
 

--- a/src/main/java/edu/self/w2k/util/DumpUtil.java
+++ b/src/main/java/edu/self/w2k/util/DumpUtil.java
@@ -1,5 +1,8 @@
 package edu.self.w2k.util;
 
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -9,12 +12,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.time.Duration;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
-public final class DumpUtil {
-
-    private static final Logger LOG = Logger.getLogger(DumpUtil.class.getName());
+@Slf4j
+@UtilityClass
+public class DumpUtil {
 
     private static final String KAIKKI_URL = "https://kaikki.org/dictionary/raw-wiktextract-data.jsonl.gz";
     private static final Path DUMP_PATH = Paths.get("dumps/raw-wiktextract-data.jsonl.gz");
@@ -26,11 +27,11 @@ public final class DumpUtil {
     public static void download() {
 
         if (Files.exists(DUMP_PATH)) {
-            LOG.info("Dump already exists at " + DUMP_PATH + ". Delete it to re-download.");
+            log.info("Dump already exists at {}. Delete it to re-download.", DUMP_PATH);
             return;
         }
 
-        LOG.info("Downloading " + KAIKKI_URL + " to " + DUMP_PATH + " …");
+        log.info("Downloading {} → {}", KAIKKI_URL, DUMP_PATH);
 
         Path partPath = DUMP_PATH.resolveSibling(DUMP_PATH.getFileName() + ".part");
         HttpClient client = HttpClient.newBuilder()
@@ -46,26 +47,22 @@ public final class DumpUtil {
                     request, HttpResponse.BodyHandlers.ofFile(partPath));
 
             if (response.statusCode() != 200) {
-                LOG.severe("HTTP " + response.statusCode() + " — download failed.");
+                log.error("Download failed — HTTP {}", response.statusCode());
                 Files.deleteIfExists(partPath);
                 return;
             }
 
             Files.move(partPath, DUMP_PATH, StandardCopyOption.REPLACE_EXISTING);
-            LOG.info("Download complete: " + DUMP_PATH + " (" + Files.size(DUMP_PATH) + " bytes)");
+            log.info("Download complete: {} ({} MB)", DUMP_PATH, Files.size(DUMP_PATH) / (1024 * 1024));
         }
         catch (Exception e) {
-            LOG.log(Level.SEVERE, e.getLocalizedMessage(), e);
+            log.error("Download failed: {}", e.getLocalizedMessage(), e);
             try { Files.deleteIfExists(partPath); } catch (Exception ignored) {}
         }
     }
 
     public static Path getDumpPath() {
         return DUMP_PATH;
-    }
-
-    private DumpUtil() {
-        throw new RuntimeException("Class should not be instantiated.");
     }
 }
 

--- a/src/main/java/edu/self/w2k/util/WiktionaryUtil.java
+++ b/src/main/java/edu/self/w2k/util/WiktionaryUtil.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import edu.self.w2k.model.WiktionaryEntry;
 import edu.self.w2k.model.WiktionaryExample;
 import edu.self.w2k.model.WiktionarySense;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.text.StringEscapeUtils;
 
 import java.io.BufferedReader;
@@ -16,18 +18,16 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.zip.GZIPInputStream;
 
-public final class WiktionaryUtil {
-
-    private static final Logger LOG = Logger.getLogger(WiktionaryUtil.class.getName());
+@Slf4j
+@UtilityClass
+public class WiktionaryUtil {
 
     public static void generateDictionary(String lang) {
 
         if (!Files.exists(DumpUtil.getDumpPath())) {
-            LOG.severe("Dump file not found: " + DumpUtil.getDumpPath() + ". Run 'download' first.");
+            log.error("Dump file not found: {}. Run 'download' first.", DumpUtil.getDumpPath());
             return;
         }
 
@@ -35,7 +35,7 @@ public final class WiktionaryUtil {
             generateDictionaryToFile(DumpUtil.getDumpPath(), lang, Path.of("dictionaries/lexicon.txt"));
         }
         catch (IOException e) {
-            LOG.log(Level.SEVERE, e.getLocalizedMessage(), e);
+            log.error("Failed to generate dictionary: {}", e.getLocalizedMessage(), e);
         }
     }
 
@@ -45,7 +45,7 @@ public final class WiktionaryUtil {
      */
     public static void generateDictionaryToFile(Path dumpFile, String lang, Path outputFile) throws IOException {
 
-        LOG.info("Language selected: " + lang + ".");
+        log.info("Generating dictionary for lang={}", lang);
         ObjectReader reader = new ObjectMapper().readerFor(WiktionaryEntry.class);
         int count = 0;
 
@@ -53,7 +53,6 @@ public final class WiktionaryUtil {
              BufferedReader lines = new BufferedReader(new InputStreamReader(gzip, StandardCharsets.UTF_8));
              BufferedWriter lexicon = new BufferedWriter(new FileWriter(outputFile.toFile(), StandardCharsets.UTF_8))) {
 
-            LOG.info("Generating entries…");
             String line;
             while ((line = lines.readLine()) != null) {
 
@@ -74,13 +73,13 @@ public final class WiktionaryUtil {
                 lexicon.write("\n");
 
                 count++;
-                if (count % 1000 == 0) {
-                    LOG.info(count + " entries written.");
+                if (count % 10_000 == 0) {
+                    log.info("{} entries written…", count);
                 }
             }
         }
 
-        LOG.info("Done. " + count + " entries written.");
+        log.info("Done. {} entries written to {}", count, outputFile);
     }
 
     /**
@@ -94,6 +93,9 @@ public final class WiktionaryUtil {
         boolean hasGloss = false;
 
         for (WiktionarySense sense : senses) {
+            if (sense == null) {
+                continue;
+            }
             List<String> glosses = sense.getGlosses();
             if (glosses.isEmpty()) {
                 continue;
@@ -112,6 +114,9 @@ public final class WiktionaryUtil {
                 boolean hasExample = false;
                 StringBuilder exSb = new StringBuilder("<ul>");
                 for (WiktionaryExample ex : examples) {
+                    if (ex == null) {
+                        continue;
+                    }
                     String text = ex.getText();
                     if (text == null || text.isBlank()) {
                         continue;
@@ -132,10 +137,6 @@ public final class WiktionaryUtil {
 
         sb.append("</ol>");
         return hasGloss ? sb.toString() : null;
-    }
-
-    private WiktionaryUtil() {
-        throw new RuntimeException("Class should not be instantiated.");
     }
 }
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,10 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss} %-5level - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary

- **Java**: 21 → 25
- **Maven plugins**: `maven-jar-plugin` 3.4.2 → 3.5.0, `maven-shade-plugin` 3.6.0 → 3.6.2

### New dependencies
| Artifact | Version |
|---|---|
| `org.projectlombok:lombok` | 1.18.38 |
| `org.slf4j:slf4j-api` | 2.0.17 |
| `ch.qos.logback:logback-classic` | 1.5.18 |

### Code changes
- **Lombok**: `@Getter` on all model classes (null-safe list getters kept manually), `@UtilityClass` on `DumpUtil` and `WiktionaryUtil`, `@Slf4j` throughout
- **Logging**: replaced `java.util.logging` with SLF4J + Logback; added `logback.xml`; improved messages (parameterised, progress every 10k entries, file size in MB, unknown-action error)
- **renovate.json**: added Renovate bot configuration

All 11 existing tests pass.