### PR TITLE
Add Java CI workflow

### DIFF
--- a/.github/workflows/java-ci.yaml
+++ b/.github/workflows/java-ci.yaml
@@ -1,0 +1,27 @@
+name: Java CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          java-version: 25
+          distribution: temurin
+          cache: maven
+
+      - run: mvn --no-transfer-progress verify


### PR DESCRIPTION
Add a GitHub Actions CI workflow that builds and tests the project on push/PR to master.

- Triggers on push, pull_request (master), and workflow_dispatch
- Java 25 Temurin with Maven cache
- Runs `mvn --no-transfer-progress verify`