### PR TITLE
Replace tab2opf Python submodule with Java OPF generator

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "scripts/tab2opf"]
-	path = scripts/tab2opf
-	url = git@github.com:nyg/tab2opf.git

--- a/README.md
+++ b/README.md
@@ -26,16 +26,15 @@ Converts a set of Wiktionary entries into a MOBI dictionary usable by a Kindle.
 
 ## How to generate your own dictionary
 
-### 1. Clone the repository & the `tab2opf` submodule
+### 1. Clone the repository
 
 ```sh
 git clone https://github.com/nyg/wiktionary-to-kindle.git
-git submodule update --init --recursive
 ```
 
 ### 2. Build the project
 
-[Apache Maven](https://maven.apache.org) is required.
+[Apache Maven](https://maven.apache.org) and Java 25 are required.
 
 ```sh
 mvn package
@@ -49,28 +48,27 @@ Downloads `raw-wiktextract-data.jsonl.gz` (~1–2 GB compressed) from kaikki.org
 java -jar target/wiktionary-to-kindle-1.0.0.jar download
 ```
 
-### 4. Generate the dictionary file
+### 4. Generate the dictionary files
 
 Filter entries for the language of your choice using its [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1) code (e.g. `el` for Greek, `fr` for French, `de` for German). The dump is streamed and decompressed on the fly — no extra disk space needed.
 
+This step writes `dictionaries/lexicon.txt` (one `word<TAB>definition` per line), then generates the Kindle OPF and HTML files directly in `dictionaries/`.
+
 ```sh
+# Source language only — target defaults to English, title is auto-generated
 java -jar target/wiktionary-to-kindle-1.0.0.jar generate el
+
+# With explicit target language and custom title
+java -jar target/wiktionary-to-kindle-1.0.0.jar generate el en "Greek–English Dictionary"
 ```
 
-### 5. Generate an OPF file from the dictionary file
-
-The dictionary file has been generated in `dictionaries/lexicon.txt`. To convert it into an OPF file, execute the commands below. Python 3 is required. The `-s` and `-t` options are the source and target languages respectively.
-
-```sh
-cd dictionaries
-python ../scripts/tab2opf/tab2opf.py -s el -t en -o "Greek–English Dictionary" lexicon.txt
-```
-
-### 6. Convert the OPF into a MOBI eBook
+### 5. Convert the OPF into a MOBI eBook
 
 Convert the OPF file into a MOBI eBook using KindleGen.
 
 ```sh
+cd dictionaries
+
 # Linux
 ../scripts/kindlegen_linux/kindlegen dictionary-el-en.opf
 
@@ -78,10 +76,10 @@ Convert the OPF file into a MOBI eBook using KindleGen.
 ../scripts/kindlegen_mac/kindlegen dictionary-el-en.opf
 
 # Windows
-..\scriptgs\kindlegen_windows\kindlegen.exe dictionary-el-en.opf
+..\scripts\kindlegen_windows\kindlegen.exe dictionary-el-en.opf
 ```
 
-### 7. Upload the file to your Kindle
+### 6. Upload the file to your Kindle
 
 If all went well, you should now have the `dictionary-el-en.mobi` file in your possession. You can either send it to your Kindle via its Kindle email address, or drag and drop it as you would with another eBook.
 
@@ -91,8 +89,7 @@ If all went well, you should now have the `dictionary-el-en.mobi` file in your p
 
 ## TODO
 
-1. Rewrite tab2opf in Java (?)
-2. tab2opf should output EPUB v2 or v3 if supported by kindlegen
+1. tab2opf should output EPUB v2 or v3 if supported by kindlegen
 	* Finding how to properly structure the OPF entries (inflected terms, etc.).
 
 ## Screenshots

--- a/src/main/java/edu/self/w2k/CLI.java
+++ b/src/main/java/edu/self/w2k/CLI.java
@@ -1,32 +1,51 @@
 package edu.self.w2k;
 
 import edu.self.w2k.util.DumpUtil;
+import edu.self.w2k.util.OpfUtil;
 import edu.self.w2k.util.WiktionaryUtil;
 import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.nio.file.Path;
 
 @Slf4j
 public class CLI {
 
+    private static final Path LEXICON_FILE = Path.of("dictionaries/lexicon.txt");
+    private static final Path DICTIONARIES_DIR = Path.of("dictionaries");
+
     public static void main(String[] args) {
 
         if (args == null || args.length == 0) {
-            log.error("No arguments provided. Usage: <action> [lang]  (actions: download, generate)");
+            log.error("No arguments provided. Usage: <action> [srcLang [trgLang [title]]]  (actions: download, generate)");
             return;
         }
 
         String action = args[0];
-        String lang = args.length > 1 ? args[1] : "en";
+        String srcLang = args.length > 1 ? args[1] : "en";
+        String trgLang = args.length > 2 ? args[2] : "en";
+        String title   = args.length > 3 ? args[3] : OpfUtil.autoTitle(srcLang, trgLang);
 
-        log.info("Running: action={}, lang={}", action, lang);
+        log.info("Running: action={}, srcLang={}, trgLang={}", action, srcLang, trgLang);
 
         if (action.matches("dl|download")) {
             DumpUtil.download();
         }
         else if (action.equals("generate")) {
-            WiktionaryUtil.generateDictionary(lang);
+            WiktionaryUtil.generateDictionary(srcLang);
+            generateOpf(srcLang, trgLang, title);
         }
         else {
-            log.error("Unknown action '{}'. Usage: <action> [lang]  (actions: download, generate)", action);
+            log.error("Unknown action '{}'. Usage: <action> [srcLang [trgLang [title]]]  (actions: download, generate)", action);
+        }
+    }
+
+    private static void generateOpf(String srcLang, String trgLang, String title) {
+        try {
+            OpfUtil.generateOpf(LEXICON_FILE, srcLang, trgLang, title, DICTIONARIES_DIR);
+        }
+        catch (IOException e) {
+            log.error("Failed to generate OPF: {}", e.getLocalizedMessage(), e);
         }
     }
 }

--- a/src/main/java/edu/self/w2k/util/OpfUtil.java
+++ b/src/main/java/edu/self/w2k/util/OpfUtil.java
@@ -1,0 +1,261 @@
+package edu.self.w2k.util;
+
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.UUID;
+
+/**
+ * Generates Kindle-compatible OPF and HTML dictionary files from a tab-delimited lexicon file.
+ *
+ * <p>Input format (one entry per line):
+ * <pre>word{TAB}definition</pre>
+ *
+ * <p>Output:
+ * <ul>
+ *   <li>{@code dictionary-{src}-{trg}-{n}.html} — Kindle MobiPocket HTML entry files (≤10,000 entries each)</li>
+ *   <li>{@code dictionary-{src}-{trg}.opf}       — OPF 2.0 manifest referencing all HTML files</li>
+ * </ul>
+ */
+@Slf4j
+@UtilityClass
+public class OpfUtil {
+
+    private static final int ENTRIES_PER_FILE = 10_000;
+
+    private static final String KINDLE_NS =
+            "https://kindlegen.s3.amazonaws.com/AmazonKindlePublishingGuidelines.pdf";
+
+    // ── public API ────────────────────────────────────────────────────────────
+
+    /**
+     * Generates OPF and HTML files from {@code lexiconFile} into {@code outputDir}.
+     *
+     * @param lexiconFile tab-delimited lexicon ({@code word\tdefinition} per line)
+     * @param srcLang     ISO 639-1 source language code (e.g. {@code "el"})
+     * @param trgLang     ISO 639-1 target language code (e.g. {@code "en"})
+     * @param title       human-readable dictionary title for the OPF metadata
+     * @param outputDir   directory where output files are written
+     */
+    public static void generateOpf(Path lexiconFile, String srcLang, String trgLang,
+                                   String title, Path outputDir) throws IOException {
+
+        log.info("Generating OPF for lang={}->{}, title=\"{}\"", srcLang, trgLang, title);
+
+        TreeMap<String, List<String[]>> defs = readLexicon(lexiconFile);
+        log.info("{} unique keys loaded from lexicon", defs.size());
+
+        List<String> htmlFileNames = writeHtmlFiles(defs, outputDir, srcLang, trgLang);
+        writeOpfFile(outputDir, srcLang, trgLang, title, htmlFileNames);
+
+        log.info("OPF generation complete: {} HTML file(s) + 1 OPF", htmlFileNames.size());
+    }
+
+    /**
+     * Builds an auto-generated title from the source and target language codes.
+     * Example: {@code "el"} + {@code "en"} → {@code "Modern Greek–English Dictionary"}.
+     */
+    public static String autoTitle(String srcLang, String trgLang) {
+        String src = Locale.forLanguageTag(srcLang).getDisplayLanguage(Locale.ENGLISH);
+        String trg = Locale.forLanguageTag(trgLang).getDisplayLanguage(Locale.ENGLISH);
+        if (src.isBlank()) src = srcLang.toUpperCase(Locale.ROOT);
+        if (trg.isBlank()) trg = trgLang.toUpperCase(Locale.ROOT);
+        return src + "\u2013" + trg + " Dictionary";
+    }
+
+    // ── step 1: read and group ────────────────────────────────────────────────
+
+    /**
+     * Reads the lexicon file and groups entries by normalised key.
+     * The returned {@link TreeMap} is sorted alphabetically by key.
+     * Each value is a list of {@code [term, definition]} pairs sharing that key.
+     */
+    static TreeMap<String, List<String[]>> readLexicon(Path lexiconFile) throws IOException {
+
+        TreeMap<String, List<String[]>> defs = new TreeMap<>();
+
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(Files.newInputStream(lexiconFile), StandardCharsets.UTF_8))) {
+
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.isBlank() || line.startsWith("#")) {
+                    continue;
+                }
+                int tab = line.indexOf('\t');
+                if (tab < 0) {
+                    log.warn("Skipping malformed line (no tab): {}", line);
+                    continue;
+                }
+                String term = line.substring(0, tab).strip();
+                String defn = line.substring(tab + 1);
+                String key = normaliseKey(term);
+                if (key.isEmpty()) {
+                    log.warn("Skipping entry with empty key: {}", term);
+                    continue;
+                }
+                defs.computeIfAbsent(key, k -> new ArrayList<>()).add(new String[]{term, defn});
+            }
+        }
+
+        return defs;
+    }
+
+    /**
+     * Normalises a term into a lookup key: lowercase, strip, replace {@code "} with {@code '},
+     * and escape {@code <}/{@code >} for the Kindle index.
+     */
+    static String normaliseKey(String term) {
+        return term
+                .replace('"', '\'')
+                .replace("<", "\\<")
+                .replace(">", "\\>")
+                .toLowerCase(Locale.ROOT)
+                .strip();
+    }
+
+    // ── step 2: write HTML files ──────────────────────────────────────────────
+
+    /**
+     * Writes the HTML dictionary files in chunks of {@value #ENTRIES_PER_FILE} keys.
+     *
+     * @return list of HTML file names (base names only, relative to outputDir)
+     */
+    private static List<String> writeHtmlFiles(TreeMap<String, List<String[]>> defs,
+                                               Path outputDir, String srcLang, String trgLang)
+            throws IOException {
+
+        List<String> fileNames = new ArrayList<>();
+        List<Map.Entry<String, List<String[]>>> entries = new ArrayList<>(defs.entrySet());
+
+        for (int start = 0, fileIndex = 0; start < entries.size(); start += ENTRIES_PER_FILE, fileIndex++) {
+            int end = Math.min(start + ENTRIES_PER_FILE, entries.size());
+            String fileName = htmlFileName(srcLang, trgLang, fileIndex);
+            writeHtmlFile(outputDir.resolve(fileName), entries.subList(start, end));
+            fileNames.add(fileName);
+            log.debug("Wrote {} ({} entries)", fileName, end - start);
+        }
+
+        return fileNames;
+    }
+
+    private static String htmlFileName(String srcLang, String trgLang, int index) {
+        return "dictionary-%s-%s-%d.html".formatted(srcLang, trgLang, index).toLowerCase(Locale.ROOT);
+    }
+
+    private static void writeHtmlFile(Path file, List<Map.Entry<String, List<String[]>>> entries)
+            throws IOException {
+
+        try (BufferedWriter w = new BufferedWriter(
+                new OutputStreamWriter(Files.newOutputStream(file), StandardCharsets.UTF_8))) {
+
+            w.write("""
+                    <html xmlns:mbp="%s"
+                          xmlns:idx="%s">
+                    <head>
+                        <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+                    </head>
+                    <body>
+                        <mbp:pagebreak/>
+                        <mbp:frameset>
+                            <mbp:slave-frame display="bottom" device="all" breadth="auto" leftmargin="0" rightmargin="0" bottommargin="0" topmargin="0">
+                                <div align="center" bgcolor="yellow">
+                                    <a onclick="index_search()">Dictionary Search</a>
+                                </div>
+                            </mbp:slave-frame>
+                            <mbp:pagebreak/>
+                    """.formatted(KINDLE_NS, KINDLE_NS));
+
+            for (var entry : entries) {
+                writeEntry(w, entry.getKey(), entry.getValue());
+            }
+
+            w.write("""
+                        </mbp:frameset>
+                    </body>
+                    </html>
+                    """);
+        }
+    }
+
+    /**
+     * Writes a single {@code <idx:entry>} block for one key.
+     * When multiple terms share the same key, their definitions are joined with {@code "; "}.
+     */
+    private static void writeEntry(BufferedWriter w, String key, List<String[]> termDefs)
+            throws IOException {
+
+        // Display the first term as the heading; join all definitions.
+        String displayTerm = termDefs.getFirst()[0];
+        StringBuilder combinedDef = new StringBuilder();
+        for (int i = 0; i < termDefs.size(); i++) {
+            if (i > 0) combinedDef.append("; ");
+            combinedDef.append(termDefs.get(i)[1]);
+        }
+
+        w.write("""
+                        <idx:entry name="word" scriptable="yes">
+                            <idx:orth value="%s"><strong>%s</strong></idx:orth>
+                            %s
+                        </idx:entry>
+                """.formatted(key, displayTerm, combinedDef));
+    }
+
+    // ── step 3: write OPF file ────────────────────────────────────────────────
+
+    private static void writeOpfFile(Path outputDir, String srcLang, String trgLang,
+                                     String title, List<String> htmlFileNames) throws IOException {
+
+        Path opfFile = outputDir.resolve("dictionary-%s-%s.opf".formatted(srcLang, trgLang).toLowerCase(Locale.ROOT));
+
+        try (BufferedWriter w = new BufferedWriter(
+                new OutputStreamWriter(Files.newOutputStream(opfFile), StandardCharsets.UTF_8))) {
+
+            w.write("""
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <package version="2.0" xmlns="http://www.idpf.org/2007/opf" unique-identifier="uid">
+                    <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+                        <dc:identifier id="uid">%s</dc:identifier>
+                        <dc:title>%s</dc:title>
+                        <dc:language>%s</dc:language>
+                        <x-metadata>
+                            <DictionaryInLanguage>%s</DictionaryInLanguage>
+                            <DictionaryOutLanguage>%s</DictionaryOutLanguage>
+                        </x-metadata>
+                    </metadata>
+                    <manifest>
+                    """.formatted(UUID.randomUUID(), title, srcLang, srcLang, trgLang));
+
+            for (int i = 0; i < htmlFileNames.size(); i++) {
+                w.write("    <item id=\"dictionary%d\" href=\"%s\" media-type=\"application/xhtml+xml\"/>\n"
+                        .formatted(i, htmlFileNames.get(i)));
+            }
+
+            w.write("</manifest>\n<spine>\n");
+            for (int i = 0; i < htmlFileNames.size(); i++) {
+                w.write("    <itemref idref=\"dictionary%d\"/>\n".formatted(i));
+            }
+
+            w.write("""
+                    </spine>
+                    <guide>
+                        <reference type="search" title="Dictionary Search" onclick="index_search()"/>
+                    </guide>
+                    </package>
+                    """);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the `tab2opf` Python submodule with a native Java implementation, eliminating the Python 3 dependency and the git submodule. The entire pipeline now runs as a single `java -jar` command.

## Changes

### New: `OpfUtil`
- Reads `lexicon.txt` (tab-delimited), normalises keys (lowercase + char escaping), groups same-key entries
- Writes Kindle MobiPocket HTML files (≤10,000 entries per file) with correct `xmlns:idx`/`xmlns:mbp` namespace URIs
- Writes an OPF 2.0 manifest with UUID identifier and `DictionaryInLanguage`/`DictionaryOutLanguage` metadata

### Updated: `CLI`
The `generate` command now accepts optional `trgLang` and `title` arguments:
```sh
# title auto-generated as "Modern Greek–English Dictionary"
java -jar wiktionary-to-kindle-1.0.0.jar generate el

# explicit target language and title
java -jar wiktionary-to-kindle-1.0.0.jar generate el en "Greek–English Dictionary"
```
`lexicon.txt` is still written as before (useful for debugging).

### Removed: `scripts/tab2opf` submodule
No Python 3 required. No `git submodule update --init` required.

### Updated: `README.md`
Removed Python/submodule setup steps; updated the generate step to show the new arguments.

## Testing
All 11 existing unit tests pass (`mvn package`).
