### PR TITLE
test: integration tests for full generate pipeline + program flow diagram

### DIFF
--- a/docs/program-flow.md
+++ b/docs/program-flow.md
@@ -1,0 +1,77 @@
+# Program Flow
+
+```mermaid
+sequenceDiagram
+    actor User
+
+    box CLI
+        participant CLI
+    end
+
+    box Utilities
+        participant DumpUtil
+        participant WiktionaryUtil
+        participant OpfUtil
+    end
+
+    participant kaikki.org
+    participant FileSystem
+
+    %% ── download command ──────────────────────────────────────────────────────
+    User->>CLI: java -jar ... download
+
+    CLI->>DumpUtil: download()
+    DumpUtil->>FileSystem: exists(dumps/raw-wiktextract-data.jsonl.gz)?
+
+    alt file already exists
+        FileSystem-->>DumpUtil: true
+        DumpUtil-->>CLI: skip (log info)
+    else file not present
+        FileSystem-->>DumpUtil: false
+        DumpUtil->>kaikki.org: GET /dictionary/raw-wiktextract-data.jsonl.gz
+        kaikki.org-->>DumpUtil: 200 OK (stream)
+        DumpUtil->>FileSystem: write to .part file
+        DumpUtil->>FileSystem: rename .part → dumps/raw-wiktextract-data.jsonl.gz
+        DumpUtil-->>CLI: done
+    end
+
+    CLI-->>User: exit
+
+    %% ── generate command ──────────────────────────────────────────────────────
+    User->>CLI: java -jar ... generate [srcLang [trgLang [title]]]
+
+    CLI->>WiktionaryUtil: generateDictionary(srcLang)
+    WiktionaryUtil->>FileSystem: open dumps/raw-wiktextract-data.jsonl.gz (GZIPInputStream)
+    FileSystem-->>WiktionaryUtil: JSONL stream
+
+    loop for each JSONL line
+        WiktionaryUtil->>WiktionaryUtil: parse WiktionaryEntry (Jackson)
+        WiktionaryUtil->>WiktionaryUtil: filter by lang_code == srcLang
+        WiktionaryUtil->>WiktionaryUtil: buildDefinition(senses) → HTML string
+        WiktionaryUtil->>WiktionaryUtil: skip form_of-only entries (null definition)
+    end
+
+    WiktionaryUtil->>FileSystem: write dictionaries/lexicon.txt (word TAB HTML)
+    WiktionaryUtil-->>CLI: done
+
+    CLI->>OpfUtil: generateOpf(lexicon, srcLang, trgLang, title, outDir)
+    OpfUtil->>FileSystem: read dictionaries/lexicon.txt
+    OpfUtil->>OpfUtil: readLexicon → TreeMap<normalisedKey, entries>
+    Note over OpfUtil: keys lowercased, " → ', < and > escaped,<br/>same normalised key grouped together
+
+    loop for each chunk of ≤10 000 entries
+        OpfUtil->>FileSystem: write dictionary-{src}-{trg}-N.html
+        Note over OpfUtil: idx:entry + idx:orth + strong term + definition
+    end
+
+    OpfUtil->>FileSystem: write dictionary-{src}-{trg}.opf
+    Note over OpfUtil: OPF 2.0, UUID dc:identifier,<br/>DictionaryInLanguage / DictionaryOutLanguage,<br/>manifest + spine entries for every HTML file
+
+    OpfUtil-->>CLI: done
+    CLI-->>User: exit
+
+    %% ── kindlegen (manual step) ───────────────────────────────────────────────
+    Note over User,FileSystem: Optional manual step — run kindlegen externally
+    User->>FileSystem: kindlegen dictionaries/dictionary-{src}-{trg}.opf
+    FileSystem-->>User: dictionaries/dictionary-{src}-{trg}.mobi
+```

--- a/src/main/java/edu/self/w2k/util/OpfUtil.java
+++ b/src/main/java/edu/self/w2k/util/OpfUtil.java
@@ -71,8 +71,9 @@ public class OpfUtil {
     public static String autoTitle(String srcLang, String trgLang) {
         String src = Locale.forLanguageTag(srcLang).getDisplayLanguage(Locale.ENGLISH);
         String trg = Locale.forLanguageTag(trgLang).getDisplayLanguage(Locale.ENGLISH);
-        if (src.isBlank()) src = srcLang.toUpperCase(Locale.ROOT);
-        if (trg.isBlank()) trg = trgLang.toUpperCase(Locale.ROOT);
+        // Locale returns the bare tag for unknown codes — uppercase it as a readable fallback.
+        if (src.isBlank() || src.equalsIgnoreCase(srcLang)) src = srcLang.toUpperCase(Locale.ROOT);
+        if (trg.isBlank() || trg.equalsIgnoreCase(trgLang)) trg = trgLang.toUpperCase(Locale.ROOT);
         return src + "\u2013" + trg + " Dictionary";
     }
 

--- a/src/test/java/edu/self/w2k/FullPipelineTest.java
+++ b/src/test/java/edu/self/w2k/FullPipelineTest.java
@@ -1,0 +1,201 @@
+package edu.self.w2k;
+
+import edu.self.w2k.util.OpfUtil;
+import edu.self.w2k.util.WiktionaryUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.BufferedWriter;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.zip.GZIPOutputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * End-to-end integration tests for the generate pipeline:
+ *
+ *   gzip JSONL dump  →  WiktionaryUtil.generateDictionaryToFile
+ *                    →  OpfUtil.generateOpf
+ *                    →  HTML + OPF files
+ *
+ * The download step (DumpUtil) requires a live HTTP connection and is not
+ * covered here. All other steps run with synthetic in-memory test data.
+ */
+class FullPipelineTest {
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private static Path writeGzipJsonl(Path dir, List<String> lines) throws IOException {
+        Path gzip = dir.resolve("dump.jsonl.gz");
+        try (GZIPOutputStream gz = new GZIPOutputStream(new FileOutputStream(gzip.toFile()));
+             BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(gz, StandardCharsets.UTF_8))) {
+            for (String line : lines) {
+                bw.write(line);
+                bw.newLine();
+            }
+        }
+        return gzip;
+    }
+
+    private static String readFile(Path file) throws IOException {
+        return Files.readString(file, StandardCharsets.UTF_8);
+    }
+
+    // ── tests ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void fullPipeline_jsonlDumpToOpf(@TempDir Path tempDir) throws IOException {
+        Path dump = writeGzipJsonl(tempDir, List.of(
+                "{\"word\":\"hello\",\"lang_code\":\"en\",\"senses\":[{\"glosses\":[\"a greeting\"],\"examples\":[{\"text\":\"Hello, world!\"}]}]}",
+                "{\"word\":\"world\",\"lang_code\":\"en\",\"senses\":[{\"glosses\":[\"the earth\"],\"examples\":[]}]}"
+        ));
+        Path lexicon = tempDir.resolve("lexicon.txt");
+
+        WiktionaryUtil.generateDictionaryToFile(dump, "en", lexicon);
+        OpfUtil.generateOpf(lexicon, "en", "en", "English–English Dictionary", tempDir);
+
+        assertTrue(Files.exists(tempDir.resolve("dictionary-en-en-0.html")), "HTML file must be created");
+        assertTrue(Files.exists(tempDir.resolve("dictionary-en-en.opf")), "OPF file must be created");
+    }
+
+    @Test
+    void fullPipeline_langFilteringApplied(@TempDir Path tempDir) throws IOException {
+        // Dump has English, German and Spanish entries.
+        Path dump = writeGzipJsonl(tempDir, List.of(
+                "{\"word\":\"hello\",\"lang_code\":\"en\",\"senses\":[{\"glosses\":[\"a greeting\"],\"examples\":[]}]}",
+                "{\"word\":\"Hund\",\"lang_code\":\"de\",\"senses\":[{\"glosses\":[\"dog\"],\"examples\":[]}]}",
+                "{\"word\":\"gato\",\"lang_code\":\"es\",\"senses\":[{\"glosses\":[\"cat\"],\"examples\":[]}]}"
+        ));
+        Path lexicon = tempDir.resolve("lexicon.txt");
+
+        WiktionaryUtil.generateDictionaryToFile(dump, "en", lexicon);
+        OpfUtil.generateOpf(lexicon, "en", "en", "Test", tempDir);
+
+        String html = readFile(tempDir.resolve("dictionary-en-en-0.html"));
+        assertTrue(html.contains("hello"), "English entry must appear in output");
+        assertFalse(html.contains("Hund"), "German entry must be excluded");
+        assertFalse(html.contains("gato"), "Spanish entry must be excluded");
+    }
+
+    @Test
+    void fullPipeline_definitionContentPreserved(@TempDir Path tempDir) throws IOException {
+        // Glosses and example text should survive the full pipeline unchanged.
+        Path dump = writeGzipJsonl(tempDir, List.of(
+                "{\"word\":\"run\",\"lang_code\":\"en\",\"senses\":[{\"glosses\":[\"move at speed\"],\"examples\":[{\"text\":\"She runs every morning.\"}]}]}"
+        ));
+        Path lexicon = tempDir.resolve("lexicon.txt");
+
+        WiktionaryUtil.generateDictionaryToFile(dump, "en", lexicon);
+        OpfUtil.generateOpf(lexicon, "en", "en", "Test", tempDir);
+
+        String html = readFile(tempDir.resolve("dictionary-en-en-0.html"));
+        assertTrue(html.contains("move at speed"), "gloss must appear in HTML");
+        assertTrue(html.contains("She runs every morning."), "example must appear in HTML");
+    }
+
+    @Test
+    void fullPipeline_formOfEntriesExcluded(@TempDir Path tempDir) throws IOException {
+        // form_of entries have no glosses and must be silently skipped.
+        Path dump = writeGzipJsonl(tempDir, List.of(
+                "{\"word\":\"ran\",\"lang_code\":\"en\",\"senses\":[{\"form_of\":[{\"word\":\"run\"}]}]}",
+                "{\"word\":\"run\",\"lang_code\":\"en\",\"senses\":[{\"glosses\":[\"to move fast\"],\"examples\":[]}]}"
+        ));
+        Path lexicon = tempDir.resolve("lexicon.txt");
+
+        WiktionaryUtil.generateDictionaryToFile(dump, "en", lexicon);
+        OpfUtil.generateOpf(lexicon, "en", "en", "Test", tempDir);
+
+        String html = readFile(tempDir.resolve("dictionary-en-en-0.html"));
+        assertTrue(html.contains("value=\"run\""), "base form must appear");
+        assertFalse(html.contains("value=\"ran\""), "form_of entry must be excluded");
+    }
+
+    @Test
+    void fullPipeline_xmlSpecialCharsEscaped(@TempDir Path tempDir) throws IOException {
+        Path dump = writeGzipJsonl(tempDir, List.of(
+                "{\"word\":\"ampersand\",\"lang_code\":\"en\",\"senses\":[{\"glosses\":[\"bread & butter\"],\"examples\":[]}]}"
+        ));
+        Path lexicon = tempDir.resolve("lexicon.txt");
+
+        WiktionaryUtil.generateDictionaryToFile(dump, "en", lexicon);
+        OpfUtil.generateOpf(lexicon, "en", "en", "Test", tempDir);
+
+        String html = readFile(tempDir.resolve("dictionary-en-en-0.html"));
+        assertTrue(html.contains("bread &amp; butter"), "& must be XML-escaped in HTML");
+        assertFalse(html.contains("bread & butter"), "unescaped & must not appear in HTML");
+    }
+
+    @Test
+    void fullPipeline_multipleEntriesProduceValidOpf(@TempDir Path tempDir) throws IOException {
+        List<String> entries = List.of(
+                "{\"word\":\"alpha\",\"lang_code\":\"en\",\"senses\":[{\"glosses\":[\"first letter\"],\"examples\":[]}]}",
+                "{\"word\":\"beta\",\"lang_code\":\"en\",\"senses\":[{\"glosses\":[\"second letter\"],\"examples\":[]}]}",
+                "{\"word\":\"gamma\",\"lang_code\":\"en\",\"senses\":[{\"glosses\":[\"third letter\"],\"examples\":[]}]}"
+        );
+        Path dump = writeGzipJsonl(tempDir, entries);
+        Path lexicon = tempDir.resolve("lexicon.txt");
+
+        WiktionaryUtil.generateDictionaryToFile(dump, "en", lexicon);
+        OpfUtil.generateOpf(lexicon, "en", "fr", "English–French Dictionary", tempDir);
+
+        String opf = readFile(tempDir.resolve("dictionary-en-fr.opf"));
+        String html = readFile(tempDir.resolve("dictionary-en-fr-0.html"));
+
+        assertTrue(opf.contains("<DictionaryInLanguage>en</DictionaryInLanguage>"), "DictionaryInLanguage must be 'en'");
+        assertTrue(opf.contains("<DictionaryOutLanguage>fr</DictionaryOutLanguage>"), "DictionaryOutLanguage must be 'fr'");
+        assertTrue(opf.contains("<dc:title>English\u2013French Dictionary</dc:title>"), "OPF title must match");
+        assertTrue(html.contains("value=\"alpha\""));
+        assertTrue(html.contains("value=\"beta\""));
+        assertTrue(html.contains("value=\"gamma\""));
+    }
+
+    @Test
+    void fullPipeline_entriesAreSortedInOutput(@TempDir Path tempDir) throws IOException {
+        // Dump is in reverse alphabetical order; output must be sorted.
+        Path dump = writeGzipJsonl(tempDir, List.of(
+                "{\"word\":\"zebra\",\"lang_code\":\"en\",\"senses\":[{\"glosses\":[\"striped animal\"],\"examples\":[]}]}",
+                "{\"word\":\"apple\",\"lang_code\":\"en\",\"senses\":[{\"glosses\":[\"fruit\"],\"examples\":[]}]}",
+                "{\"word\":\"mango\",\"lang_code\":\"en\",\"senses\":[{\"glosses\":[\"tropical fruit\"],\"examples\":[]}]}"
+        ));
+        Path lexicon = tempDir.resolve("lexicon.txt");
+
+        WiktionaryUtil.generateDictionaryToFile(dump, "en", lexicon);
+        OpfUtil.generateOpf(lexicon, "en", "en", "Test", tempDir);
+
+        String html = readFile(tempDir.resolve("dictionary-en-en-0.html"));
+        int applePos = html.indexOf("value=\"apple\"");
+        int mangoPos = html.indexOf("value=\"mango\"");
+        int zebraPos = html.indexOf("value=\"zebra\"");
+
+        assertTrue(applePos < mangoPos, "apple must precede mango in output");
+        assertTrue(mangoPos < zebraPos, "mango must precede zebra in output");
+    }
+
+    @Test
+    void fullPipeline_greekToEnglish(@TempDir Path tempDir) throws IOException {
+        Path dump = writeGzipJsonl(tempDir, List.of(
+                "{\"word\":\"σκύλος\",\"lang_code\":\"el\",\"senses\":[{\"glosses\":[\"dog\"],\"examples\":[{\"text\":\"Ο σκύλος τρέχει.\"}]}]}",
+                "{\"word\":\"γάτα\",\"lang_code\":\"el\",\"senses\":[{\"glosses\":[\"cat\"],\"examples\":[]}]}"
+        ));
+        Path lexicon = tempDir.resolve("lexicon.txt");
+
+        WiktionaryUtil.generateDictionaryToFile(dump, "el", lexicon);
+
+        String title = OpfUtil.autoTitle("el", "en");
+        OpfUtil.generateOpf(lexicon, "el", "en", title, tempDir);
+
+        String opf = readFile(tempDir.resolve("dictionary-el-en.opf"));
+        String html = readFile(tempDir.resolve("dictionary-el-en-0.html"));
+
+        assertTrue(opf.contains("<dc:language>el</dc:language>"));
+        assertTrue(html.contains("<strong>σκύλος</strong>"), "Greek term must appear as display word");
+        assertTrue(html.contains("dog"), "English gloss must be present");
+        assertTrue(html.contains("Ο σκύλος τρέχει."), "Greek example must pass through");
+    }
+}

--- a/src/test/java/edu/self/w2k/util/OpfUtilTest.java
+++ b/src/test/java/edu/self/w2k/util/OpfUtilTest.java
@@ -1,0 +1,293 @@
+package edu.self.w2k.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.TreeMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OpfUtilTest {
+
+    // ── normaliseKey unit tests ───────────────────────────────────────────────
+
+    @Test
+    void normaliseKey_lowercases() {
+        assertEquals("hello", OpfUtil.normaliseKey("Hello"));
+        assertEquals("hello", OpfUtil.normaliseKey("HELLO"));
+    }
+
+    @Test
+    void normaliseKey_stripsWhitespace() {
+        assertEquals("hello", OpfUtil.normaliseKey("  hello  "));
+    }
+
+    @Test
+    void normaliseKey_replacesDoubleQuotes() {
+        assertEquals("it's", OpfUtil.normaliseKey("it\"s"));
+    }
+
+    @Test
+    void normaliseKey_escapesAngleBrackets() {
+        assertEquals("a \\< b \\> c", OpfUtil.normaliseKey("A < B > C"));
+    }
+
+    // ── autoTitle unit tests ──────────────────────────────────────────────────
+
+    @Test
+    void autoTitle_knownLanguageCodes() {
+        String title = OpfUtil.autoTitle("fr", "en");
+        assertTrue(title.contains("French"), "should contain 'French', got: " + title);
+        assertTrue(title.contains("English"), "should contain 'English', got: " + title);
+        assertTrue(title.endsWith("Dictionary"), "should end with 'Dictionary'");
+    }
+
+    @Test
+    void autoTitle_unknownCodeFallsBackToUpperCase() {
+        String title = OpfUtil.autoTitle("xx", "en");
+        assertTrue(title.contains("XX"), "unknown code should fall back to upper-case, got: " + title);
+    }
+
+    // ── generateOpf integration tests ────────────────────────────────────────
+
+    @Test
+    void generateOpf_createsExpectedFiles(@TempDir Path tempDir) throws IOException {
+        writeLexicon(tempDir, "hello\t<ol><li>a greeting</li></ol>");
+
+        OpfUtil.generateOpf(tempDir.resolve("lexicon.txt"), "en", "fr", "Test Dictionary", tempDir);
+
+        assertTrue(Files.exists(tempDir.resolve("dictionary-en-fr-0.html")), "HTML file should exist");
+        assertTrue(Files.exists(tempDir.resolve("dictionary-en-fr.opf")), "OPF file should exist");
+    }
+
+    @Test
+    void generateOpf_htmlHasCorrectKindleNamespaces(@TempDir Path tempDir) throws IOException {
+        writeLexicon(tempDir, "word\t<ol><li>definition</li></ol>");
+
+        OpfUtil.generateOpf(tempDir.resolve("lexicon.txt"), "el", "en", "Test", tempDir);
+
+        String html = readFile(tempDir.resolve("dictionary-el-en-0.html"));
+        String kindleNs = "https://kindlegen.s3.amazonaws.com/AmazonKindlePublishingGuidelines.pdf";
+        assertTrue(html.contains("xmlns:mbp=\"" + kindleNs + "\""), "mbp namespace URI must be exact");
+        assertTrue(html.contains("xmlns:idx=\"" + kindleNs + "\""), "idx namespace URI must be exact");
+    }
+
+    @Test
+    void generateOpf_htmlHasCorrectEntryStructure(@TempDir Path tempDir) throws IOException {
+        writeLexicon(tempDir, "hello\t<ol><li>a greeting</li></ol>");
+
+        OpfUtil.generateOpf(tempDir.resolve("lexicon.txt"), "el", "en", "Test", tempDir);
+
+        String html = readFile(tempDir.resolve("dictionary-el-en-0.html"));
+        assertTrue(html.contains("<idx:entry name=\"word\" scriptable=\"yes\">"),
+                "entry element must have correct attributes");
+        assertTrue(html.contains("<idx:orth value=\"hello\">"),
+                "orth value must be the normalised key");
+        assertTrue(html.contains("<strong>hello</strong>"), "display term in <strong>");
+        assertTrue(html.contains("<ol><li>a greeting</li></ol>"), "definition passed through unchanged");
+    }
+
+    @Test
+    void generateOpf_opfHasCorrectStructure(@TempDir Path tempDir) throws Exception {
+        writeLexicon(tempDir, "hello\t<ol><li>a greeting</li></ol>");
+
+        OpfUtil.generateOpf(tempDir.resolve("lexicon.txt"), "el", "en", "Greek\u2013English Dictionary", tempDir);
+
+        Document doc = parseXml(tempDir.resolve("dictionary-el-en.opf"));
+
+        // package version
+        assertEquals("2.0", doc.getDocumentElement().getAttribute("version"),
+                "OPF package must be version 2.0");
+
+        // dc:title
+        NodeList titles = doc.getElementsByTagName("dc:title");
+        assertEquals(1, titles.getLength());
+        assertEquals("Greek\u2013English Dictionary", titles.item(0).getTextContent());
+
+        // dc:language
+        NodeList langs = doc.getElementsByTagName("dc:language");
+        assertEquals(1, langs.getLength());
+        assertEquals("el", langs.item(0).getTextContent());
+
+        // dc:identifier is a non-blank UUID
+        NodeList ids = doc.getElementsByTagName("dc:identifier");
+        assertEquals(1, ids.getLength());
+        String uid = ids.item(0).getTextContent();
+        assertFalse(uid.isBlank(), "dc:identifier must not be blank");
+        assertDoesNotThrow(() -> java.util.UUID.fromString(uid), "dc:identifier must be a valid UUID");
+
+        // DictionaryInLanguage / DictionaryOutLanguage
+        String opf = readFile(tempDir.resolve("dictionary-el-en.opf"));
+        assertTrue(opf.contains("<DictionaryInLanguage>el</DictionaryInLanguage>"));
+        assertTrue(opf.contains("<DictionaryOutLanguage>en</DictionaryOutLanguage>"));
+
+        // manifest and spine reference the HTML file
+        assertTrue(opf.contains("href=\"dictionary-el-en-0.html\""), "manifest must reference HTML file");
+        assertTrue(opf.contains("idref=\"dictionary0\""), "spine must reference dictionary0");
+    }
+
+    @Test
+    void generateOpf_entriesAreSorted(@TempDir Path tempDir) throws IOException {
+        // Entries written in reverse alphabetical order.
+        writeLexicon(tempDir,
+                "zebra\t<ol><li>animal</li></ol>",
+                "apple\t<ol><li>fruit</li></ol>",
+                "mango\t<ol><li>fruit</li></ol>");
+
+        OpfUtil.generateOpf(tempDir.resolve("lexicon.txt"), "en", "en", "Test", tempDir);
+
+        String html = readFile(tempDir.resolve("dictionary-en-en-0.html"));
+        int applePos = html.indexOf("value=\"apple\"");
+        int mangoPos = html.indexOf("value=\"mango\"");
+        int zebraPos = html.indexOf("value=\"zebra\"");
+
+        assertTrue(applePos < mangoPos, "apple should appear before mango");
+        assertTrue(mangoPos < zebraPos, "mango should appear before zebra");
+    }
+
+    @Test
+    void generateOpf_keyNormalisationApplied(@TempDir Path tempDir) throws IOException {
+        // Term "Hello" should produce key "hello".
+        writeLexicon(tempDir, "Hello\t<ol><li>a greeting</li></ol>");
+
+        OpfUtil.generateOpf(tempDir.resolve("lexicon.txt"), "en", "en", "Test", tempDir);
+
+        String html = readFile(tempDir.resolve("dictionary-en-en-0.html"));
+        assertTrue(html.contains("value=\"hello\""), "key must be lowercased");
+        assertTrue(html.contains("<strong>Hello</strong>"), "display term preserves original capitalisation");
+    }
+
+    @Test
+    void generateOpf_sameKeyEntriesAreGrouped(@TempDir Path tempDir) throws IOException {
+        // "Apple" and "apple" normalise to the same key → one idx:entry, joined definitions.
+        writeLexicon(tempDir,
+                "Apple\t<ol><li>a fruit</li></ol>",
+                "apple\t<ol><li>a tech company</li></ol>");
+
+        OpfUtil.generateOpf(tempDir.resolve("lexicon.txt"), "en", "en", "Test", tempDir);
+
+        String html = readFile(tempDir.resolve("dictionary-en-en-0.html"));
+        long entryCount = html.lines()
+                .filter(l -> l.contains("<idx:entry name=\"word\""))
+                .count();
+        assertEquals(1, entryCount,
+                "both terms share the same key → should produce exactly one idx:entry");
+        assertTrue(html.contains("a fruit"), "first definition must be present");
+        assertTrue(html.contains("a tech company"), "second definition must be present");
+        assertTrue(html.indexOf("a fruit") < html.indexOf("a tech company"),
+                "definitions should be joined in insertion order");
+    }
+
+    @Test
+    void generateOpf_splitIntoChunksOfTenThousand(@TempDir Path tempDir) throws IOException {
+        // 10,001 unique entries must produce 2 HTML files.
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i <= 10_000; i++) {
+            sb.append("word%05d\t<ol><li>def %d</li></ol>\n".formatted(i, i));
+        }
+        Files.writeString(tempDir.resolve("lexicon.txt"), sb.toString(), StandardCharsets.UTF_8);
+
+        OpfUtil.generateOpf(tempDir.resolve("lexicon.txt"), "en", "en", "Test", tempDir);
+
+        assertTrue(Files.exists(tempDir.resolve("dictionary-en-en-0.html")), "first HTML file must exist");
+        assertTrue(Files.exists(tempDir.resolve("dictionary-en-en-1.html")), "second HTML file must exist");
+        assertFalse(Files.exists(tempDir.resolve("dictionary-en-en-2.html")),
+                "no third file for 10,001 entries");
+
+        // OPF must reference both files.
+        String opf = readFile(tempDir.resolve("dictionary-en-en.opf"));
+        assertTrue(opf.contains("href=\"dictionary-en-en-0.html\""));
+        assertTrue(opf.contains("href=\"dictionary-en-en-1.html\""));
+    }
+
+    @Test
+    void generateOpf_skipBlankAndCommentLines(@TempDir Path tempDir) throws IOException {
+        writeLexicon(tempDir,
+                "",
+                "# this is a comment",
+                "hello\t<ol><li>a greeting</li></ol>",
+                "   ",
+                "# another comment");
+
+        OpfUtil.generateOpf(tempDir.resolve("lexicon.txt"), "en", "en", "Test", tempDir);
+
+        String html = readFile(tempDir.resolve("dictionary-en-en-0.html"));
+        long entryCount = html.lines()
+                .filter(l -> l.contains("<idx:entry name=\"word\""))
+                .count();
+        assertEquals(1, entryCount, "only one real entry — blank/comment lines must be skipped");
+    }
+
+    @Test
+    void generateOpf_autoTitleIncludesLanguageNames(@TempDir Path tempDir) throws IOException {
+        writeLexicon(tempDir, "bonjour\t<ol><li>hello</li></ol>");
+
+        String title = OpfUtil.autoTitle("fr", "en");
+        OpfUtil.generateOpf(tempDir.resolve("lexicon.txt"), "fr", "en", title, tempDir);
+
+        String opf = readFile(tempDir.resolve("dictionary-fr-en.opf"));
+        assertTrue(opf.contains("<dc:title>" + title + "</dc:title>"),
+                "OPF title must match the auto-generated title");
+        assertTrue(title.contains("French"), "auto title should mention French, got: " + title);
+    }
+
+    // ── readLexicon unit tests ────────────────────────────────────────────────
+
+    @Test
+    void readLexicon_groupsSameNormalisedKey(@TempDir Path tempDir) throws IOException {
+        writeLexicon(tempDir,
+                "Run\t<ol><li>to move fast</li></ol>",
+                "run\t<ol><li>a running session</li></ol>");
+
+        TreeMap<String, List<String[]>> defs = OpfUtil.readLexicon(tempDir.resolve("lexicon.txt"));
+
+        assertEquals(1, defs.size(), "both terms normalise to 'run' → one key");
+        List<String[]> entries = defs.get("run");
+        assertNotNull(entries);
+        assertEquals(2, entries.size(), "two term-definition pairs under the same key");
+    }
+
+    @Test
+    void readLexicon_sortsKeysAlphabetically(@TempDir Path tempDir) throws IOException {
+        writeLexicon(tempDir,
+                "zoo\t<ol><li>animal park</li></ol>",
+                "ant\t<ol><li>insect</li></ol>",
+                "cat\t<ol><li>feline</li></ol>");
+
+        TreeMap<String, List<String[]>> defs = OpfUtil.readLexicon(tempDir.resolve("lexicon.txt"));
+
+        List<String> keys = List.copyOf(defs.keySet());
+        assertEquals(List.of("ant", "cat", "zoo"), keys, "keys must be in alphabetical order");
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private static void writeLexicon(Path dir, String... lines) throws IOException {
+        Files.writeString(dir.resolve("lexicon.txt"),
+                String.join("\n", lines) + "\n",
+                StandardCharsets.UTF_8);
+    }
+
+    private static String readFile(Path file) throws IOException {
+        return Files.readString(file, StandardCharsets.UTF_8);
+    }
+
+    private static Document parseXml(Path file) throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        // Suppress DTD resolution errors (OPF may reference external DTDs).
+        builder.setEntityResolver((publicId, systemId) ->
+                new org.xml.sax.InputSource(new java.io.StringReader("")));
+        return builder.parse(file.toFile());
+    }
+}


### PR DESCRIPTION
Expands test coverage to the whole generate pipeline and adds a program flow diagram.

## New: `FullPipelineTest` (8 tests)

End-to-end integration tests covering the complete generate pipeline using synthetic in-memory data (no real dump file needed):

- `fullPipeline_jsonlDumpToOpf` — gzip JSONL → lexicon → HTML + OPF files created
- `fullPipeline_langFilteringApplied` — only entries with the right `lang_code` appear in output
- `fullPipeline_definitionContentPreserved` — glosses and examples survive the full pipeline unchanged
- `fullPipeline_formOfEntriesExcluded` — `form_of`-only entries are silently skipped
- `fullPipeline_xmlSpecialCharsEscaped` — `&` → `&amp;` throughout the pipeline
- `fullPipeline_multipleEntriesProduceValidOpf` — OPF language metadata and titles correct
- `fullPipeline_entriesAreSortedInOutput` — entries arrive in random order, HTML output is alphabetical
- `fullPipeline_greekToEnglish` — Unicode terms and examples pass through correctly

> The download step (`DumpUtil`) performs a live HTTP request and is not covered here.

## Updated: `OpfUtilTest` (18 tests)

Unit and integration tests for `OpfUtil` in isolation (unchanged from previous commit).

## New: `docs/program-flow.md`

Mermaid sequence diagram illustrating both CLI commands:

- **`download`** — skip-if-exists check → HTTP GET to kaikki.org → atomic `.part` rename
- **`generate`** — JSONL stream filtering → `lexicon.txt` → HTML chunks + OPF manifest → optional `kindlegen` step

## Summary

| Test class | Tests |
|---|---|
| `FullPipelineTest` | 8 (new) |
| `OpfUtilTest` | 18 |
| `WiktionaryUtilTest` | 11 |
| **Total** | **37** |