### PR TITLE
feat: introduce LexiconEntry record, LexiconWriter interface, TsvLexiconWriter

### DIFF
--- a/src/main/java/edu/self/w2k/lexicon/LexiconEntry.java
+++ b/src/main/java/edu/self/w2k/lexicon/LexiconEntry.java
@@ -1,0 +1,3 @@
+package edu.self.w2k.lexicon;
+
+public record LexiconEntry(String word, String definition) {}

--- a/src/main/java/edu/self/w2k/lexicon/LexiconWriter.java
+++ b/src/main/java/edu/self/w2k/lexicon/LexiconWriter.java
@@ -1,0 +1,10 @@
+package edu.self.w2k.lexicon;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+public interface LexiconWriter {
+
+    void write(Path outputFile, Stream<LexiconEntry> entries) throws IOException;
+}

--- a/src/main/java/edu/self/w2k/lexicon/TsvLexiconWriter.java
+++ b/src/main/java/edu/self/w2k/lexicon/TsvLexiconWriter.java
@@ -1,0 +1,31 @@
+package edu.self.w2k.lexicon;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
+
+@Slf4j
+public class TsvLexiconWriter implements LexiconWriter {
+
+    @Override
+    public void write(Path outputFile, Stream<LexiconEntry> entries) throws IOException {
+        AtomicLong count = new AtomicLong();
+        try (BufferedWriter writer = Files.newBufferedWriter(outputFile, StandardCharsets.UTF_8);
+             Stream<LexiconEntry> stream = entries) {
+            for (LexiconEntry entry : (Iterable<LexiconEntry>) stream::iterator) {
+                writer.write(entry.word());
+                writer.write("\t");
+                writer.write(entry.definition());
+                writer.write("\n");
+                count.incrementAndGet();
+            }
+        }
+        log.info("Done. {} entries written to {}", count.get(), outputFile);
+    }
+}

--- a/src/test/java/edu/self/w2k/lexicon/TsvLexiconWriterTest.java
+++ b/src/test/java/edu/self/w2k/lexicon/TsvLexiconWriterTest.java
@@ -1,0 +1,60 @@
+package edu.self.w2k.lexicon;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TsvLexiconWriterTest {
+
+    private final TsvLexiconWriter writer = new TsvLexiconWriter();
+
+    @Test
+    void write_singleEntry(@TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve("lexicon.txt");
+        writer.write(file, Stream.of(new LexiconEntry("hello", "<b>greeting</b>")));
+
+        String content = Files.readString(file);
+        assertEquals("hello\t<b>greeting</b>\n", content);
+    }
+
+    @Test
+    void write_multipleEntries(@TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve("lexicon.txt");
+        writer.write(file, Stream.of(
+                new LexiconEntry("alpha", "first"),
+                new LexiconEntry("beta", "second"),
+                new LexiconEntry("gamma", "third")
+        ));
+
+        List<String> lines = Files.readAllLines(file);
+        assertEquals(3, lines.size());
+        assertEquals("alpha\tfirst", lines.get(0));
+        assertEquals("beta\tsecond", lines.get(1));
+        assertEquals("gamma\tthird", lines.get(2));
+    }
+
+    @Test
+    void write_emptyStream(@TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve("lexicon.txt");
+        writer.write(file, Stream.empty());
+
+        assertTrue(Files.readString(file).isEmpty());
+    }
+
+    @Test
+    void write_tabInDefinition(@TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve("lexicon.txt");
+        writer.write(file, Stream.of(new LexiconEntry("word", "def\twith\ttabs")));
+
+        String content = Files.readString(file);
+        assertEquals("word\tdef\twith\ttabs\n", content);
+    }
+}


### PR DESCRIPTION
Closes #24

Introduces the `lexicon/` package with `LexiconEntry` record (shared value object), `LexiconWriter` interface, and `TsvLexiconWriter` implementation. Adds 4 unit tests.