### PR TITLE
feat: introduce DefinitionRenderer interface and HtmlDefinitionRenderer

### DIFF
--- a/src/main/java/edu/self/w2k/render/DefinitionRenderer.java
+++ b/src/main/java/edu/self/w2k/render/DefinitionRenderer.java
@@ -1,0 +1,15 @@
+package edu.self.w2k.render;
+
+import edu.self.w2k.model.WiktionarySense;
+
+import java.util.List;
+
+public interface DefinitionRenderer {
+
+    /**
+     * Renders a list of senses into a definition string.
+     *
+     * @return the rendered definition, or {@code null} if the entry has no renderable glosses
+     */
+    String render(List<WiktionarySense> senses);
+}

--- a/src/main/java/edu/self/w2k/render/HtmlDefinitionRenderer.java
+++ b/src/main/java/edu/self/w2k/render/HtmlDefinitionRenderer.java
@@ -1,0 +1,53 @@
+package edu.self.w2k.render;
+
+import edu.self.w2k.model.WiktionaryExample;
+import edu.self.w2k.model.WiktionarySense;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.text.StringEscapeUtils;
+
+import java.util.List;
+
+@Slf4j
+public class HtmlDefinitionRenderer implements DefinitionRenderer {
+
+    @Override
+    public String render(List<WiktionarySense> senses) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<ol>");
+        boolean hasGloss = false;
+
+        for (WiktionarySense sense : senses) {
+            if (sense == null) continue;
+            List<String> glosses = sense.getGlosses();
+            if (glosses.isEmpty()) continue;
+
+            for (String gloss : glosses) {
+                if (gloss == null || gloss.isBlank()) continue;
+                hasGloss = true;
+                sb.append("<li><span>");
+                sb.append(StringEscapeUtils.escapeXml10(gloss.replaceAll("[\n\r]", "; ")));
+                sb.append("</span>");
+
+                List<WiktionaryExample> examples = sense.getExamples();
+                boolean hasExample = false;
+                StringBuilder exSb = new StringBuilder("<ul>");
+                for (WiktionaryExample ex : examples) {
+                    if (ex == null) continue;
+                    String text = ex.getText();
+                    if (text == null || text.isBlank()) continue;
+                    hasExample = true;
+                    exSb.append("<li>");
+                    exSb.append(StringEscapeUtils.escapeXml10(text.replaceAll("[\n\r]", "; ")));
+                    exSb.append("</li>");
+                }
+                exSb.append("</ul>");
+                if (hasExample) sb.append(exSb);
+
+                sb.append("</li>");
+            }
+        }
+
+        sb.append("</ol>");
+        return hasGloss ? sb.toString() : null;
+    }
+}

--- a/src/test/java/edu/self/w2k/render/HtmlDefinitionRendererTest.java
+++ b/src/test/java/edu/self/w2k/render/HtmlDefinitionRendererTest.java
@@ -1,0 +1,99 @@
+package edu.self.w2k.render;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HtmlDefinitionRendererTest {
+
+    private final DefinitionRenderer renderer = new HtmlDefinitionRenderer();
+
+    @Test
+    void buildDefinition_basicGloss() {
+        var senses = List.of(parseSense("{\"glosses\":[\"a dog\"],\"examples\":[]}"));
+        String def = renderer.render(senses);
+        assertNotNull(def);
+        assertTrue(def.contains("<ol>"), "should wrap in <ol>");
+        assertTrue(def.contains("<li><span>a dog</span>"), "should contain gloss");
+        assertFalse(def.contains("<ul>"), "no examples → no <ul>");
+    }
+
+    @Test
+    void buildDefinition_xmlEscaping() {
+        var senses = List.of(parseSense("{\"glosses\":[\"bread & butter <food>\"],\"examples\":[]}"));
+        String def = renderer.render(senses);
+        assertNotNull(def);
+        assertTrue(def.contains("bread &amp; butter &lt;food&gt;"), "XML characters should be escaped");
+    }
+
+    @Test
+    void buildDefinition_withExample() {
+        var senses = List.of(parseSense("{\"glosses\":[\"run\"],\"examples\":[{\"text\":\"He runs fast.\"}]}"));
+        String def = renderer.render(senses);
+        assertNotNull(def);
+        assertTrue(def.contains("<ul>"), "examples present → <ul>");
+        assertTrue(def.contains("<li>He runs fast.</li>"));
+    }
+
+    @Test
+    void buildDefinition_stripsNewlines() {
+        var senses = List.of(parseSense("{\"glosses\":[\"line1\\nline2\"],\"examples\":[]}"));
+        String def = renderer.render(senses);
+        assertNotNull(def);
+        assertTrue(def.contains("line1; line2"), "newlines should be replaced with '; '");
+    }
+
+    @Test
+    void buildDefinition_multipleGlossesInOneSense() {
+        var senses = List.of(parseSense("{\"glosses\":[\"first meaning\",\"second meaning\"],\"examples\":[]}"));
+        String def = renderer.render(senses);
+        assertNotNull(def);
+        assertTrue(def.contains("first meaning"));
+        assertTrue(def.contains("second meaning"));
+    }
+
+    @Test
+    void buildDefinition_nullSensesSkipped() {
+        var senses = List.of(parseSense("{\"glosses\":[],\"examples\":[]}"));
+        assertNull(renderer.render(senses), "form_of-only entries should return null");
+    }
+
+    @Test
+    void buildDefinition_blankGlossSkipped() {
+        var senses = List.of(parseSense("{\"glosses\":[\"  \"],\"examples\":[]}"));
+        assertNull(renderer.render(senses), "blank gloss should be skipped → null");
+    }
+
+    @Test
+    void buildDefinition_blankExampleSkipped() {
+        var senses = List.of(parseSense("{\"glosses\":[\"gloss\"],\"examples\":[{\"text\":\"  \"}]}"));
+        String def = renderer.render(senses);
+        assertNotNull(def);
+        assertFalse(def.contains("<ul>"), "blank example should be skipped → no <ul>");
+    }
+
+    @Test
+    void buildDefinition_greekContent() {
+        var senses = List.of(parseSense("{\"glosses\":[\"σκύλος (dog)\"],\"examples\":[{\"text\":\"Ο σκύλος τρέχει.\"}]}"));
+        String def = renderer.render(senses);
+        assertNotNull(def);
+        assertTrue(def.contains("σκύλος (dog)"), "Greek gloss should pass through unchanged");
+        assertTrue(def.contains("Ο σκύλος τρέχει."), "Greek example should pass through unchanged");
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static edu.self.w2k.model.WiktionarySense parseSense(String json) {
+        try {
+            return new com.fasterxml.jackson.databind.ObjectMapper()
+                    .readerFor(edu.self.w2k.model.WiktionarySense.class)
+                    .readValue(json);
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Closes #21

Introduces the `render/` package with `DefinitionRenderer` interface and `HtmlDefinitionRenderer` implementation. All 9 `buildDefinition_*` test cases migrated to `HtmlDefinitionRendererTest`.