### PR TITLE
feat: introduce DictionaryParser interface and JsonlDictionaryParser

### DIFF
--- a/src/main/java/edu/self/w2k/parse/DictionaryParser.java
+++ b/src/main/java/edu/self/w2k/parse/DictionaryParser.java
@@ -1,0 +1,12 @@
+package edu.self.w2k.parse;
+
+import edu.self.w2k.model.WiktionaryEntry;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+public interface DictionaryParser {
+
+    Stream<WiktionaryEntry> parse(Path dumpFile, String lang) throws IOException;
+}

--- a/src/main/java/edu/self/w2k/parse/JsonlDictionaryParser.java
+++ b/src/main/java/edu/self/w2k/parse/JsonlDictionaryParser.java
@@ -1,0 +1,50 @@
+package edu.self.w2k.parse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import edu.self.w2k.model.WiktionaryEntry;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import java.util.zip.GZIPInputStream;
+
+@Slf4j
+public class JsonlDictionaryParser implements DictionaryParser {
+
+    @Override
+    public Stream<WiktionaryEntry> parse(Path dumpFile, String lang) throws IOException {
+
+        log.info("Parsing dump for lang={}", lang);
+        ObjectReader reader = new ObjectMapper().readerFor(WiktionaryEntry.class);
+        List<WiktionaryEntry> entries = new ArrayList<>();
+        int matched = 0;
+
+        try (GZIPInputStream gzip = new GZIPInputStream(Files.newInputStream(dumpFile));
+             BufferedReader lines = new BufferedReader(new InputStreamReader(gzip, StandardCharsets.UTF_8))) {
+
+            String line;
+            while ((line = lines.readLine()) != null) {
+                WiktionaryEntry entry = reader.readValue(line);
+                if (!lang.equals(entry.getLangCode()) || entry.getWord() == null) {
+                    continue;
+                }
+                entries.add(entry);
+                matched++;
+                if (matched % 10_000 == 0) {
+                    log.info("{} entries matched…", matched);
+                }
+            }
+        }
+
+        log.info("Done. {} entries matched for lang={}", matched, lang);
+        return entries.stream();
+    }
+}

--- a/src/test/java/edu/self/w2k/parse/JsonlDictionaryParserTest.java
+++ b/src/test/java/edu/self/w2k/parse/JsonlDictionaryParserTest.java
@@ -1,0 +1,77 @@
+package edu.self.w2k.parse;
+
+import edu.self.w2k.model.WiktionaryEntry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.BufferedWriter;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.zip.GZIPOutputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JsonlDictionaryParserTest {
+
+    private static Path writeGzipJsonl(Path dir, String filename, List<String> lines) throws IOException {
+        Path gzip = dir.resolve(filename);
+        try (GZIPOutputStream gz = new GZIPOutputStream(new FileOutputStream(gzip.toFile()));
+             BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(gz, StandardCharsets.UTF_8))) {
+            for (String line : lines) {
+                writer.write(line);
+                writer.newLine();
+            }
+        }
+        return gzip;
+    }
+
+    @Test
+    void parse_filtersCorrectLanguage(@TempDir Path tempDir) throws IOException {
+        List<String> jsonlLines = List.of(
+                "{\"word\":\"gatos\",\"lang_code\":\"es\",\"senses\":[{\"glosses\":[\"cats\"],\"examples\":[]}]}",
+                "{\"word\":\"\u03c3\u03ba\u03cd\u03bb\u03bf\u03c2\",\"lang_code\":\"el\",\"senses\":[{\"glosses\":[\"dog\"],\"examples\":[]}]}",
+                "{\"word\":\"Hund\",\"lang_code\":\"de\",\"senses\":[{\"glosses\":[\"dog\"],\"examples\":[]}]}"
+        );
+        Path dumpFile = writeGzipJsonl(tempDir, "test.jsonl.gz", jsonlLines);
+
+        List<WiktionaryEntry> result = new JsonlDictionaryParser().parse(dumpFile, "el").collect(Collectors.toList());
+
+        assertEquals(1, result.size(), "only the Greek entry should be returned");
+        assertEquals("\u03c3\u03ba\u03cd\u03bb\u03bf\u03c2", result.get(0).getWord());
+        assertEquals("el", result.get(0).getLangCode());
+    }
+
+    @Test
+    void parse_skipsNullWord(@TempDir Path tempDir) throws IOException {
+        List<String> jsonlLines = List.of(
+                "{\"lang_code\":\"el\",\"senses\":[{\"glosses\":[\"something\"],\"examples\":[]}]}",
+                "{\"word\":\"\u03c4\u03c1\u03ad\u03c7\u03c9\",\"lang_code\":\"el\",\"senses\":[{\"glosses\":[\"to run\"],\"examples\":[]}]}"
+        );
+        Path dumpFile = writeGzipJsonl(tempDir, "test.jsonl.gz", jsonlLines);
+
+        List<WiktionaryEntry> result = new JsonlDictionaryParser().parse(dumpFile, "el").collect(Collectors.toList());
+
+        assertEquals(1, result.size(), "entry with null word should be skipped");
+        assertEquals("\u03c4\u03c1\u03ad\u03c7\u03c9", result.get(0).getWord());
+    }
+
+    @Test
+    void parse_skipsOtherLanguages(@TempDir Path tempDir) throws IOException {
+        List<String> jsonlLines = List.of(
+                "{\"word\":\"cat\",\"lang_code\":\"en\",\"senses\":[{\"glosses\":[\"feline\"],\"examples\":[]}]}",
+                "{\"word\":\"chat\",\"lang_code\":\"fr\",\"senses\":[{\"glosses\":[\"cat\"],\"examples\":[]}]}",
+                "{\"word\":\"gato\",\"lang_code\":\"es\",\"senses\":[{\"glosses\":[\"cat\"],\"examples\":[]}]}"
+        );
+        Path dumpFile = writeGzipJsonl(tempDir, "test.jsonl.gz", jsonlLines);
+
+        List<WiktionaryEntry> result = new JsonlDictionaryParser().parse(dumpFile, "fr").collect(Collectors.toList());
+
+        assertEquals(1, result.size(), "only the French entry should be returned");
+        assertEquals("chat", result.get(0).getWord());
+    }
+}


### PR DESCRIPTION
Closes #22

Introduces the `parse/` package with `DictionaryParser` interface and `JsonlDictionaryParser` implementation. Adds `JsonlDictionaryParserTest`.