### PR TITLE
feat: introduce LexiconReader interface and TsvLexiconReader

### DIFF
--- a/src/main/java/edu/self/w2k/lexicon/LexiconEntry.java
+++ b/src/main/java/edu/self/w2k/lexicon/LexiconEntry.java
@@ -1,0 +1,3 @@
+package edu.self.w2k.lexicon;
+
+public record LexiconEntry(String word, String definition) {}

--- a/src/main/java/edu/self/w2k/lexicon/LexiconReader.java
+++ b/src/main/java/edu/self/w2k/lexicon/LexiconReader.java
@@ -1,0 +1,10 @@
+package edu.self.w2k.lexicon;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.TreeMap;
+
+public interface LexiconReader {
+    TreeMap<String, List<LexiconEntry>> read(Path lexiconFile) throws IOException;
+}

--- a/src/main/java/edu/self/w2k/lexicon/LexiconWriter.java
+++ b/src/main/java/edu/self/w2k/lexicon/LexiconWriter.java
@@ -1,0 +1,10 @@
+package edu.self.w2k.lexicon;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+public interface LexiconWriter {
+
+    void write(Path outputFile, Stream<LexiconEntry> entries) throws IOException;
+}

--- a/src/main/java/edu/self/w2k/lexicon/TsvLexiconReader.java
+++ b/src/main/java/edu/self/w2k/lexicon/TsvLexiconReader.java
@@ -1,0 +1,64 @@
+package edu.self.w2k.lexicon;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.TreeMap;
+
+@Slf4j
+public class TsvLexiconReader implements LexiconReader {
+
+    @Override
+    public TreeMap<String, List<LexiconEntry>> read(Path lexiconFile) throws IOException {
+
+        TreeMap<String, List<LexiconEntry>> defs = new TreeMap<>();
+
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(Files.newInputStream(lexiconFile), StandardCharsets.UTF_8))) {
+
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.isBlank() || line.startsWith("#")) {
+                    continue;
+                }
+                int tab = line.indexOf('\t');
+                if (tab < 0) {
+                    log.warn("Skipping malformed line (no tab): {}", line);
+                    continue;
+                }
+                String word = line.substring(0, tab).strip();
+                String definition = line.substring(tab + 1);
+                String key = normaliseKey(word);
+                if (key.isEmpty()) {
+                    log.warn("Skipping entry with empty key: {}", word);
+                    continue;
+                }
+                defs.computeIfAbsent(key, k -> new ArrayList<>()).add(new LexiconEntry(word, definition));
+            }
+        }
+
+        log.info("{} unique keys read from lexicon", defs.size());
+        return defs;
+    }
+
+    /**
+     * Normalises a word into a lookup key: lowercase, strip, replace {@code "} with {@code '},
+     * and escape {@code <}/{@code >} for the Kindle index.
+     */
+    static String normaliseKey(String word) {
+        return word
+                .replace('"', '\'')
+                .replace("<", "\\<")
+                .replace(">", "\\>")
+                .toLowerCase(Locale.ROOT)
+                .strip();
+    }
+}

--- a/src/main/java/edu/self/w2k/lexicon/TsvLexiconWriter.java
+++ b/src/main/java/edu/self/w2k/lexicon/TsvLexiconWriter.java
@@ -1,0 +1,31 @@
+package edu.self.w2k.lexicon;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
+
+@Slf4j
+public class TsvLexiconWriter implements LexiconWriter {
+
+    @Override
+    public void write(Path outputFile, Stream<LexiconEntry> entries) throws IOException {
+        AtomicLong count = new AtomicLong();
+        try (BufferedWriter writer = Files.newBufferedWriter(outputFile, StandardCharsets.UTF_8);
+             Stream<LexiconEntry> stream = entries) {
+            for (LexiconEntry entry : (Iterable<LexiconEntry>) stream::iterator) {
+                writer.write(entry.word());
+                writer.write("\t");
+                writer.write(entry.definition());
+                writer.write("\n");
+                count.incrementAndGet();
+            }
+        }
+        log.info("Done. {} entries written to {}", count.get(), outputFile);
+    }
+}

--- a/src/test/java/edu/self/w2k/lexicon/TsvLexiconReaderTest.java
+++ b/src/test/java/edu/self/w2k/lexicon/TsvLexiconReaderTest.java
@@ -1,0 +1,143 @@
+package edu.self.w2k.lexicon;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.TreeMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TsvLexiconReaderTest {
+
+    private final TsvLexiconReader reader = new TsvLexiconReader();
+
+    // ── normaliseKey unit tests ───────────────────────────────────────────────
+
+    @Test
+    void normaliseKey_lowercases() {
+        assertEquals("hello", TsvLexiconReader.normaliseKey("Hello"));
+        assertEquals("hello", TsvLexiconReader.normaliseKey("HELLO"));
+    }
+
+    @Test
+    void normaliseKey_stripsWhitespace() {
+        assertEquals("hello", TsvLexiconReader.normaliseKey("  hello  "));
+    }
+
+    @Test
+    void normaliseKey_replacesDoubleQuotes() {
+        assertEquals("it's", TsvLexiconReader.normaliseKey("it\"s"));
+    }
+
+    @Test
+    void normaliseKey_escapesAngleBrackets() {
+        assertEquals("a \\< b \\> c", TsvLexiconReader.normaliseKey("A < B > C"));
+    }
+
+    // ── read() unit tests ─────────────────────────────────────────────────────
+
+    @Test
+    void read_singleEntry(@TempDir Path tempDir) throws IOException {
+        Path file = writeLexicon(tempDir, "hello\t<ol><li>a greeting</li></ol>");
+
+        TreeMap<String, List<LexiconEntry>> result = reader.read(file);
+
+        assertEquals(1, result.size());
+        assertTrue(result.containsKey("hello"));
+        List<LexiconEntry> entries = result.get("hello");
+        assertEquals(1, entries.size());
+        assertEquals("hello", entries.get(0).word());
+        assertEquals("<ol><li>a greeting</li></ol>", entries.get(0).definition());
+    }
+
+    @Test
+    void read_groupsEntriesByNormalisedKey(@TempDir Path tempDir) throws IOException {
+        // "Hello" and "hello" normalise to the same key → grouped together
+        Path file = writeLexicon(tempDir,
+                "Hello\t<ol><li>first</li></ol>",
+                "hello\t<ol><li>second</li></ol>");
+
+        TreeMap<String, List<LexiconEntry>> result = reader.read(file);
+
+        assertEquals(1, result.size());
+        List<LexiconEntry> entries = result.get("hello");
+        assertNotNull(entries);
+        assertEquals(2, entries.size());
+    }
+
+    @Test
+    void read_multipleDistinctKeys(@TempDir Path tempDir) throws IOException {
+        Path file = writeLexicon(tempDir,
+                "apple\t<ol><li>fruit</li></ol>",
+                "banana\t<ol><li>fruit</li></ol>",
+                "cherry\t<ol><li>fruit</li></ol>");
+
+        TreeMap<String, List<LexiconEntry>> result = reader.read(file);
+
+        assertEquals(3, result.size());
+        assertTrue(result.containsKey("apple"));
+        assertTrue(result.containsKey("banana"));
+        assertTrue(result.containsKey("cherry"));
+    }
+
+    @Test
+    void read_keysAreSortedAlphabetically(@TempDir Path tempDir) throws IOException {
+        Path file = writeLexicon(tempDir,
+                "zebra\t<ol><li>animal</li></ol>",
+                "apple\t<ol><li>fruit</li></ol>",
+                "mango\t<ol><li>fruit</li></ol>");
+
+        TreeMap<String, List<LexiconEntry>> result = reader.read(file);
+
+        List<String> keys = List.copyOf(result.keySet());
+        assertEquals(List.of("apple", "mango", "zebra"), keys);
+    }
+
+    @Test
+    void read_skipsBlankAndCommentLines(@TempDir Path tempDir) throws IOException {
+        Path file = writeLexicon(tempDir,
+                "# this is a comment",
+                "word\t<ol><li>def</li></ol>",
+                "");
+
+        TreeMap<String, List<LexiconEntry>> result = reader.read(file);
+
+        assertEquals(1, result.size());
+        assertTrue(result.containsKey("word"));
+    }
+
+    @Test
+    void read_skipsLinesWithoutTab(@TempDir Path tempDir) throws IOException {
+        Path file = writeLexicon(tempDir,
+                "no-tab-line",
+                "valid\t<ol><li>def</li></ol>");
+
+        TreeMap<String, List<LexiconEntry>> result = reader.read(file);
+
+        assertEquals(1, result.size());
+        assertTrue(result.containsKey("valid"));
+    }
+
+    @Test
+    void read_normaliseKeyApplied(@TempDir Path tempDir) throws IOException {
+        Path file = writeLexicon(tempDir, "UPPER\t<ol><li>def</li></ol>");
+
+        TreeMap<String, List<LexiconEntry>> result = reader.read(file);
+
+        assertFalse(result.containsKey("UPPER"), "key should be lowercased");
+        assertTrue(result.containsKey("upper"));
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private Path writeLexicon(Path dir, String... lines) throws IOException {
+        Path file = dir.resolve("lexicon.txt");
+        Files.write(file, List.of(lines), StandardCharsets.UTF_8);
+        return file;
+    }
+}

--- a/src/test/java/edu/self/w2k/lexicon/TsvLexiconWriterTest.java
+++ b/src/test/java/edu/self/w2k/lexicon/TsvLexiconWriterTest.java
@@ -1,0 +1,60 @@
+package edu.self.w2k.lexicon;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TsvLexiconWriterTest {
+
+    private final TsvLexiconWriter writer = new TsvLexiconWriter();
+
+    @Test
+    void write_singleEntry(@TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve("lexicon.txt");
+        writer.write(file, Stream.of(new LexiconEntry("hello", "<b>greeting</b>")));
+
+        String content = Files.readString(file);
+        assertEquals("hello\t<b>greeting</b>\n", content);
+    }
+
+    @Test
+    void write_multipleEntries(@TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve("lexicon.txt");
+        writer.write(file, Stream.of(
+                new LexiconEntry("alpha", "first"),
+                new LexiconEntry("beta", "second"),
+                new LexiconEntry("gamma", "third")
+        ));
+
+        List<String> lines = Files.readAllLines(file);
+        assertEquals(3, lines.size());
+        assertEquals("alpha\tfirst", lines.get(0));
+        assertEquals("beta\tsecond", lines.get(1));
+        assertEquals("gamma\tthird", lines.get(2));
+    }
+
+    @Test
+    void write_emptyStream(@TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve("lexicon.txt");
+        writer.write(file, Stream.empty());
+
+        assertTrue(Files.readString(file).isEmpty());
+    }
+
+    @Test
+    void write_tabInDefinition(@TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve("lexicon.txt");
+        writer.write(file, Stream.of(new LexiconEntry("word", "def\twith\ttabs")));
+
+        String content = Files.readString(file);
+        assertEquals("word\tdef\twith\ttabs\n", content);
+    }
+}


### PR DESCRIPTION
Closes #25

## Changes

- Add `LexiconReader` interface in `edu.self.w2k.lexicon` with `TreeMap<String, List<LexiconEntry>> read(Path)`
- Add `TsvLexiconReader` implementation that reads TSV lines, groups by normalised key
- Port `normaliseKey` logic from `OpfUtil` (lowercase, strip, `"→'`, escape `<`/`>`)
- Add `TsvLexiconReaderTest` with 11 tests: 4 `normaliseKey_*` cases migrated from `OpfUtilTest`, 7 `read()` tests