### PR TITLE
feat: introduce OpfGenerator interface and KindleOpfGenerator

### DIFF
--- a/src/main/java/edu/self/w2k/opf/KindleOpfGenerator.java
+++ b/src/main/java/edu/self/w2k/opf/KindleOpfGenerator.java
@@ -1,0 +1,192 @@
+package edu.self.w2k.opf;
+
+import edu.self.w2k.lexicon.LexiconEntry;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.UUID;
+
+/**
+ * Generates Kindle-compatible OPF and HTML dictionary files from a pre-grouped lexicon.
+ *
+ * <p>Output:
+ * <ul>
+ *   <li>{@code dictionary-{src}-{trg}-{n}.html} — Kindle MobiPocket HTML entry files (≤10,000 entries each)</li>
+ *   <li>{@code dictionary-{src}-{trg}.opf}       — OPF 2.0 manifest referencing all HTML files</li>
+ * </ul>
+ */
+@Slf4j
+public class KindleOpfGenerator implements OpfGenerator {
+
+    private static final int ENTRIES_PER_FILE = 10_000;
+
+    private static final String KINDLE_NS =
+            "https://kindlegen.s3.amazonaws.com/AmazonKindlePublishingGuidelines.pdf";
+
+    @Override
+    public void generate(TreeMap<String, List<LexiconEntry>> defs, String srcLang, String trgLang,
+                         String title, Path outputDir) throws IOException {
+
+        log.info("Generating OPF for lang={}->{}, title=\"{}\"", srcLang, trgLang, title);
+        log.info("{} unique keys loaded from lexicon", defs.size());
+
+        List<String> htmlFileNames = writeHtmlFiles(defs, outputDir, srcLang, trgLang);
+        writeOpfFile(outputDir, srcLang, trgLang, title, htmlFileNames);
+
+        log.info("OPF generation complete: {} HTML file(s) + 1 OPF", htmlFileNames.size());
+    }
+
+    /**
+     * Builds an auto-generated title from the source and target language codes.
+     * Example: {@code "el"} + {@code "en"} → {@code "Modern Greek–English Dictionary"}.
+     */
+    static String autoTitle(String srcLang, String trgLang) {
+        String src = Locale.forLanguageTag(srcLang).getDisplayLanguage(Locale.ENGLISH);
+        String trg = Locale.forLanguageTag(trgLang).getDisplayLanguage(Locale.ENGLISH);
+        // Locale returns the bare tag for unknown codes — uppercase it as a readable fallback.
+        if (src.isBlank() || src.equalsIgnoreCase(srcLang)) src = srcLang.toUpperCase(Locale.ROOT);
+        if (trg.isBlank() || trg.equalsIgnoreCase(trgLang)) trg = trgLang.toUpperCase(Locale.ROOT);
+        return src + "\u2013" + trg + " Dictionary";
+    }
+
+    // ── step 1: write HTML files ──────────────────────────────────────────────
+
+    /**
+     * Writes the HTML dictionary files in chunks of {@value #ENTRIES_PER_FILE} keys.
+     *
+     * @return list of HTML file names (base names only, relative to outputDir)
+     */
+    private List<String> writeHtmlFiles(TreeMap<String, List<LexiconEntry>> defs,
+                                        Path outputDir, String srcLang, String trgLang)
+            throws IOException {
+
+        List<String> fileNames = new ArrayList<>();
+        List<Map.Entry<String, List<LexiconEntry>>> entries = new ArrayList<>(defs.entrySet());
+
+        for (int start = 0, fileIndex = 0; start < entries.size(); start += ENTRIES_PER_FILE, fileIndex++) {
+            int end = Math.min(start + ENTRIES_PER_FILE, entries.size());
+            String fileName = htmlFileName(srcLang, trgLang, fileIndex);
+            writeHtmlFile(outputDir.resolve(fileName), entries.subList(start, end));
+            fileNames.add(fileName);
+            log.debug("Wrote {} ({} entries)", fileName, end - start);
+        }
+
+        return fileNames;
+    }
+
+    private static String htmlFileName(String srcLang, String trgLang, int index) {
+        return "dictionary-%s-%s-%d.html".formatted(srcLang, trgLang, index).toLowerCase(Locale.ROOT);
+    }
+
+    private static void writeHtmlFile(Path file, List<Map.Entry<String, List<LexiconEntry>>> entries)
+            throws IOException {
+
+        try (BufferedWriter w = new BufferedWriter(
+                new OutputStreamWriter(Files.newOutputStream(file), StandardCharsets.UTF_8))) {
+
+            w.write("""
+                    <html xmlns:mbp="%s"
+                          xmlns:idx="%s">
+                    <head>
+                        <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+                    </head>
+                    <body>
+                        <mbp:pagebreak/>
+                        <mbp:frameset>
+                            <mbp:slave-frame display="bottom" device="all" breadth="auto" leftmargin="0" rightmargin="0" bottommargin="0" topmargin="0">
+                                <div align="center" bgcolor="yellow">
+                                    <a onclick="index_search()">Dictionary Search</a>
+                                </div>
+                            </mbp:slave-frame>
+                            <mbp:pagebreak/>
+                    """.formatted(KINDLE_NS, KINDLE_NS));
+
+            for (var entry : entries) {
+                writeEntry(w, entry.getKey(), entry.getValue());
+            }
+
+            w.write("""
+                        </mbp:frameset>
+                    </body>
+                    </html>
+                    """);
+        }
+    }
+
+    /**
+     * Writes a single {@code <idx:entry>} block for one key.
+     * When multiple entries share the same key, their definitions are joined with {@code "; "}.
+     */
+    private static void writeEntry(BufferedWriter w, String key, List<LexiconEntry> lexiconEntries)
+            throws IOException {
+
+        String displayTerm = lexiconEntries.getFirst().word();
+        StringBuilder combinedDef = new StringBuilder();
+        for (int i = 0; i < lexiconEntries.size(); i++) {
+            if (i > 0) combinedDef.append("; ");
+            combinedDef.append(lexiconEntries.get(i).definition());
+        }
+
+        w.write("""
+                        <idx:entry name="word" scriptable="yes">
+                            <idx:orth value="%s"><strong>%s</strong></idx:orth>
+                            %s
+                        </idx:entry>
+                """.formatted(key, displayTerm, combinedDef));
+    }
+
+    // ── step 2: write OPF file ────────────────────────────────────────────────
+
+    private static void writeOpfFile(Path outputDir, String srcLang, String trgLang,
+                                     String title, List<String> htmlFileNames) throws IOException {
+
+        Path opfFile = outputDir.resolve("dictionary-%s-%s.opf".formatted(srcLang, trgLang).toLowerCase(Locale.ROOT));
+
+        try (BufferedWriter w = new BufferedWriter(
+                new OutputStreamWriter(Files.newOutputStream(opfFile), StandardCharsets.UTF_8))) {
+
+            w.write("""
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <package version="2.0" xmlns="http://www.idpf.org/2007/opf" unique-identifier="uid">
+                    <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+                        <dc:identifier id="uid">%s</dc:identifier>
+                        <dc:title>%s</dc:title>
+                        <dc:language>%s</dc:language>
+                        <x-metadata>
+                            <DictionaryInLanguage>%s</DictionaryInLanguage>
+                            <DictionaryOutLanguage>%s</DictionaryOutLanguage>
+                        </x-metadata>
+                    </metadata>
+                    <manifest>
+                    """.formatted(UUID.randomUUID(), title, srcLang, srcLang, trgLang));
+
+            for (int i = 0; i < htmlFileNames.size(); i++) {
+                w.write("    <item id=\"dictionary%d\" href=\"%s\" media-type=\"application/xhtml+xml\"/>\n"
+                        .formatted(i, htmlFileNames.get(i)));
+            }
+
+            w.write("</manifest>\n<spine>\n");
+            for (int i = 0; i < htmlFileNames.size(); i++) {
+                w.write("    <itemref idref=\"dictionary%d\"/>\n".formatted(i));
+            }
+
+            w.write("""
+                    </spine>
+                    <guide>
+                        <reference type="search" title="Dictionary Search" onclick="index_search()"/>
+                    </guide>
+                    </package>
+                    """);
+        }
+    }
+}

--- a/src/main/java/edu/self/w2k/opf/OpfGenerator.java
+++ b/src/main/java/edu/self/w2k/opf/OpfGenerator.java
@@ -1,0 +1,11 @@
+package edu.self.w2k.opf;
+
+import edu.self.w2k.lexicon.LexiconEntry;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.TreeMap;
+
+public interface OpfGenerator {
+    void generate(TreeMap<String, List<LexiconEntry>> defs, String srcLang, String trgLang, String title, Path outputDir) throws IOException;
+}

--- a/src/test/java/edu/self/w2k/opf/KindleOpfGeneratorTest.java
+++ b/src/test/java/edu/self/w2k/opf/KindleOpfGeneratorTest.java
@@ -1,0 +1,255 @@
+package edu.self.w2k.opf;
+
+import edu.self.w2k.lexicon.LexiconEntry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.TreeMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class KindleOpfGeneratorTest {
+
+    private final KindleOpfGenerator generator = new KindleOpfGenerator();
+
+    // ── autoTitle unit tests ──────────────────────────────────────────────────
+
+    @Test
+    void autoTitle_knownLanguageCodes() {
+        String title = KindleOpfGenerator.autoTitle("fr", "en");
+        assertTrue(title.contains("French"), "should contain 'French', got: " + title);
+        assertTrue(title.contains("English"), "should contain 'English', got: " + title);
+        assertTrue(title.endsWith("Dictionary"), "should end with 'Dictionary'");
+    }
+
+    @Test
+    void autoTitle_unknownCodeFallsBackToUpperCase() {
+        String title = KindleOpfGenerator.autoTitle("xx", "en");
+        assertTrue(title.contains("XX"), "unknown code should fall back to upper-case, got: " + title);
+    }
+
+    // ── generate integration tests ────────────────────────────────────────────
+
+    @Test
+    void generateOpf_createsExpectedFiles(@TempDir Path tempDir) throws IOException {
+        TreeMap<String, List<LexiconEntry>> defs = buildDefs(
+                "hello\t<ol><li>a greeting</li></ol>");
+
+        generator.generate(defs, "en", "fr", "Test Dictionary", tempDir);
+
+        assertTrue(Files.exists(tempDir.resolve("dictionary-en-fr-0.html")), "HTML file should exist");
+        assertTrue(Files.exists(tempDir.resolve("dictionary-en-fr.opf")), "OPF file should exist");
+    }
+
+    @Test
+    void generateOpf_htmlHasCorrectKindleNamespaces(@TempDir Path tempDir) throws IOException {
+        TreeMap<String, List<LexiconEntry>> defs = buildDefs(
+                "word\t<ol><li>definition</li></ol>");
+
+        generator.generate(defs, "el", "en", "Test", tempDir);
+
+        String html = readFile(tempDir.resolve("dictionary-el-en-0.html"));
+        String kindleNs = "https://kindlegen.s3.amazonaws.com/AmazonKindlePublishingGuidelines.pdf";
+        assertTrue(html.contains("xmlns:mbp=\"" + kindleNs + "\""), "mbp namespace URI must be exact");
+        assertTrue(html.contains("xmlns:idx=\"" + kindleNs + "\""), "idx namespace URI must be exact");
+    }
+
+    @Test
+    void generateOpf_htmlHasCorrectEntryStructure(@TempDir Path tempDir) throws IOException {
+        TreeMap<String, List<LexiconEntry>> defs = buildDefs(
+                "hello\t<ol><li>a greeting</li></ol>");
+
+        generator.generate(defs, "el", "en", "Test", tempDir);
+
+        String html = readFile(tempDir.resolve("dictionary-el-en-0.html"));
+        assertTrue(html.contains("<idx:entry name=\"word\" scriptable=\"yes\">"),
+                "entry element must have correct attributes");
+        assertTrue(html.contains("<idx:orth value=\"hello\">"),
+                "orth value must be the normalised key");
+        assertTrue(html.contains("<strong>hello</strong>"), "display term in <strong>");
+        assertTrue(html.contains("<ol><li>a greeting</li></ol>"), "definition passed through unchanged");
+    }
+
+    @Test
+    void generateOpf_opfHasCorrectStructure(@TempDir Path tempDir) throws Exception {
+        TreeMap<String, List<LexiconEntry>> defs = buildDefs(
+                "hello\t<ol><li>a greeting</li></ol>");
+
+        generator.generate(defs, "el", "en", "Greek\u2013English Dictionary", tempDir);
+
+        Document doc = parseXml(tempDir.resolve("dictionary-el-en.opf"));
+
+        assertEquals("2.0", doc.getDocumentElement().getAttribute("version"),
+                "OPF package must be version 2.0");
+
+        NodeList titles = doc.getElementsByTagName("dc:title");
+        assertEquals(1, titles.getLength());
+        assertEquals("Greek\u2013English Dictionary", titles.item(0).getTextContent());
+
+        NodeList langs = doc.getElementsByTagName("dc:language");
+        assertEquals(1, langs.getLength());
+        assertEquals("el", langs.item(0).getTextContent());
+
+        NodeList ids = doc.getElementsByTagName("dc:identifier");
+        assertEquals(1, ids.getLength());
+        String uid = ids.item(0).getTextContent();
+        assertFalse(uid.isBlank(), "dc:identifier must not be blank");
+        assertDoesNotThrow(() -> java.util.UUID.fromString(uid), "dc:identifier must be a valid UUID");
+
+        String opf = readFile(tempDir.resolve("dictionary-el-en.opf"));
+        assertTrue(opf.contains("<DictionaryInLanguage>el</DictionaryInLanguage>"));
+        assertTrue(opf.contains("<DictionaryOutLanguage>en</DictionaryOutLanguage>"));
+        assertTrue(opf.contains("href=\"dictionary-el-en-0.html\""), "manifest must reference HTML file");
+        assertTrue(opf.contains("idref=\"dictionary0\""), "spine must reference dictionary0");
+    }
+
+    @Test
+    void generateOpf_entriesAreSorted(@TempDir Path tempDir) throws IOException {
+        TreeMap<String, List<LexiconEntry>> defs = buildDefs(
+                "zebra\t<ol><li>animal</li></ol>",
+                "apple\t<ol><li>fruit</li></ol>",
+                "mango\t<ol><li>fruit</li></ol>");
+
+        generator.generate(defs, "en", "en", "Test", tempDir);
+
+        String html = readFile(tempDir.resolve("dictionary-en-en-0.html"));
+        int applePos = html.indexOf("value=\"apple\"");
+        int mangoPos = html.indexOf("value=\"mango\"");
+        int zebraPos = html.indexOf("value=\"zebra\"");
+
+        assertTrue(applePos < mangoPos, "apple should appear before mango");
+        assertTrue(mangoPos < zebraPos, "mango should appear before zebra");
+    }
+
+    @Test
+    void generateOpf_keyNormalisationApplied(@TempDir Path tempDir) throws IOException {
+        // Key "hello" maps to LexiconEntry with word "Hello" (original capitalisation preserved).
+        TreeMap<String, List<LexiconEntry>> defs = new TreeMap<>();
+        defs.put("hello", List.of(new LexiconEntry("Hello", "<ol><li>a greeting</li></ol>")));
+
+        generator.generate(defs, "en", "en", "Test", tempDir);
+
+        String html = readFile(tempDir.resolve("dictionary-en-en-0.html"));
+        assertTrue(html.contains("value=\"hello\""), "key must be lowercased");
+        assertTrue(html.contains("<strong>Hello</strong>"), "display term preserves original capitalisation");
+    }
+
+    @Test
+    void generateOpf_sameKeyEntriesAreGrouped(@TempDir Path tempDir) throws IOException {
+        // "Apple" and "apple" normalise to the same key → one idx:entry, joined definitions.
+        TreeMap<String, List<LexiconEntry>> defs = new TreeMap<>();
+        List<LexiconEntry> entries = new ArrayList<>();
+        entries.add(new LexiconEntry("Apple", "<ol><li>a fruit</li></ol>"));
+        entries.add(new LexiconEntry("apple", "<ol><li>a tech company</li></ol>"));
+        defs.put("apple", entries);
+
+        generator.generate(defs, "en", "en", "Test", tempDir);
+
+        String html = readFile(tempDir.resolve("dictionary-en-en-0.html"));
+        long entryCount = html.lines()
+                .filter(l -> l.contains("<idx:entry name=\"word\""))
+                .count();
+        assertEquals(1, entryCount,
+                "both terms share the same key → should produce exactly one idx:entry");
+        assertTrue(html.contains("a fruit"), "first definition must be present");
+        assertTrue(html.contains("a tech company"), "second definition must be present");
+        assertTrue(html.indexOf("a fruit") < html.indexOf("a tech company"),
+                "definitions should be joined in insertion order");
+    }
+
+    @Test
+    void generateOpf_splitIntoChunksOfTenThousand(@TempDir Path tempDir) throws IOException {
+        TreeMap<String, List<LexiconEntry>> defs = new TreeMap<>();
+        for (int i = 0; i <= 10_000; i++) {
+            String word = "word%05d".formatted(i);
+            defs.put(word, List.of(new LexiconEntry(word, "<ol><li>def %d</li></ol>".formatted(i))));
+        }
+
+        generator.generate(defs, "en", "en", "Test", tempDir);
+
+        assertTrue(Files.exists(tempDir.resolve("dictionary-en-en-0.html")), "first HTML file must exist");
+        assertTrue(Files.exists(tempDir.resolve("dictionary-en-en-1.html")), "second HTML file must exist");
+        assertFalse(Files.exists(tempDir.resolve("dictionary-en-en-2.html")),
+                "no third file for 10,001 entries");
+
+        String opf = readFile(tempDir.resolve("dictionary-en-en.opf"));
+        assertTrue(opf.contains("href=\"dictionary-en-en-0.html\""));
+        assertTrue(opf.contains("href=\"dictionary-en-en-1.html\""));
+    }
+
+    @Test
+    void generateOpf_singleEntryProducesOneIdxEntry(@TempDir Path tempDir) throws IOException {
+        TreeMap<String, List<LexiconEntry>> defs = buildDefs(
+                "hello\t<ol><li>a greeting</li></ol>");
+
+        generator.generate(defs, "en", "en", "Test", tempDir);
+
+        String html = readFile(tempDir.resolve("dictionary-en-en-0.html"));
+        long entryCount = html.lines()
+                .filter(l -> l.contains("<idx:entry name=\"word\""))
+                .count();
+        assertEquals(1, entryCount, "a single entry in defs must produce exactly one idx:entry");
+    }
+
+    @Test
+    void generateOpf_autoTitleIncludesLanguageNames(@TempDir Path tempDir) throws IOException {
+        TreeMap<String, List<LexiconEntry>> defs = buildDefs(
+                "bonjour\t<ol><li>hello</li></ol>");
+
+        String title = KindleOpfGenerator.autoTitle("fr", "en");
+        generator.generate(defs, "fr", "en", title, tempDir);
+
+        String opf = readFile(tempDir.resolve("dictionary-fr-en.opf"));
+        assertTrue(opf.contains("<dc:title>" + title + "</dc:title>"),
+                "OPF title must match the auto-generated title");
+        assertTrue(title.contains("French"), "auto title should mention French, got: " + title);
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    /**
+     * Builds a {@link TreeMap} of defs from tab-delimited {@code word\tdefinition} strings.
+     * Entries sharing the same normalised key are grouped under that key.
+     */
+    private static TreeMap<String, List<LexiconEntry>> buildDefs(String... lines) {
+        TreeMap<String, List<LexiconEntry>> defs = new TreeMap<>();
+        for (String line : lines) {
+            int tab = line.indexOf('\t');
+            if (tab < 0) continue;
+            String term = line.substring(0, tab).strip();
+            String defn = line.substring(tab + 1);
+            String key = term.replace('"', '\'')
+                    .replace("<", "\\<")
+                    .replace(">", "\\>")
+                    .toLowerCase(Locale.ROOT)
+                    .strip();
+            if (key.isEmpty()) continue;
+            defs.computeIfAbsent(key, k -> new ArrayList<>()).add(new LexiconEntry(term, defn));
+        }
+        return defs;
+    }
+
+    private static String readFile(Path file) throws IOException {
+        return Files.readString(file, StandardCharsets.UTF_8);
+    }
+
+    private static Document parseXml(Path file) throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        builder.setEntityResolver((publicId, systemId) ->
+                new org.xml.sax.InputSource(new java.io.StringReader("")));
+        return builder.parse(file.toFile());
+    }
+}


### PR DESCRIPTION
Introduces the `OpfGenerator` interface and `KindleOpfGenerator` implementation in the `opf/` package, porting all logic from `OpfUtil.writeHtmlFiles`, `writeOpfFile`, and `autoTitle`.

Closes #26