### PR TITLE
feat: introduce Command pattern and refactor CLI as composition root

### DIFF
--- a/src/main/java/edu/self/w2k/CLI.java
+++ b/src/main/java/edu/self/w2k/CLI.java
@@ -1,51 +1,62 @@
 package edu.self.w2k;
 
-import edu.self.w2k.util.DumpUtil;
-import edu.self.w2k.util.OpfUtil;
-import edu.self.w2k.util.WiktionaryUtil;
+import edu.self.w2k.command.DownloadCommand;
+import edu.self.w2k.command.GenerateCommand;
+import edu.self.w2k.download.KaikkiDumpDownloader;
+import edu.self.w2k.lexicon.TsvLexiconReader;
+import edu.self.w2k.lexicon.TsvLexiconWriter;
+import edu.self.w2k.opf.KindleOpfGenerator;
+import edu.self.w2k.parse.JsonlDictionaryParser;
+import edu.self.w2k.render.HtmlDefinitionRenderer;
 import lombok.extern.slf4j.Slf4j;
 
-import java.io.IOException;
 import java.nio.file.Path;
 
 @Slf4j
 public class CLI {
 
+    private static final Path DUMP_FILE    = Path.of("dumps/raw-wiktextract-data.jsonl.gz");
     private static final Path LEXICON_FILE = Path.of("dictionaries/lexicon.txt");
     private static final Path DICTIONARIES_DIR = Path.of("dictionaries");
 
     public static void main(String[] args) {
 
         if (args == null || args.length == 0) {
-            log.error("No arguments provided. Usage: <action> [srcLang [trgLang [title]]]  (actions: download, generate)");
+            log.error("No arguments provided. Usage: <action> [lang]  (actions: download, generate)");
             return;
         }
 
         String action = args[0];
-        String srcLang = args.length > 1 ? args[1] : "en";
-        String trgLang = args.length > 2 ? args[2] : "en";
-        String title   = args.length > 3 ? args[3] : OpfUtil.autoTitle(srcLang, trgLang);
+        String lang = args.length > 1 ? args[1] : "en";
 
-        log.info("Running: action={}, srcLang={}, trgLang={}", action, srcLang, trgLang);
+        log.info("Running: action={}, lang={}", action, lang);
 
-        if (action.matches("dl|download")) {
-            DumpUtil.download();
-        }
-        else if (action.equals("generate")) {
-            WiktionaryUtil.generateDictionary(srcLang);
-            generateOpf(srcLang, trgLang, title);
-        }
-        else {
-            log.error("Unknown action '{}'. Usage: <action> [srcLang [trgLang [title]]]  (actions: download, generate)", action);
-        }
-    }
-
-    private static void generateOpf(String srcLang, String trgLang, String title) {
         try {
-            OpfUtil.generateOpf(LEXICON_FILE, srcLang, trgLang, title, DICTIONARIES_DIR);
+            if (action.matches("dl|download")) {
+                new DownloadCommand(new KaikkiDumpDownloader()).run();
+            }
+            else if (action.equals("generate")) {
+                String title = KindleOpfGenerator.autoTitle(lang, lang);
+                new GenerateCommand(
+                        new JsonlDictionaryParser(),
+                        new HtmlDefinitionRenderer(),
+                        new TsvLexiconWriter(),
+                        new TsvLexiconReader(),
+                        new KindleOpfGenerator(),
+                        DUMP_FILE,
+                        LEXICON_FILE,
+                        DICTIONARIES_DIR,
+                        lang,
+                        title
+                ).run();
+            }
+            else {
+                log.error("Unknown action '{}'. Usage: <action> [lang]  (actions: download, generate)", action);
+            }
         }
-        catch (IOException e) {
-            log.error("Failed to generate OPF: {}", e.getLocalizedMessage(), e);
+        catch (Exception e) {
+            log.error("Command failed: {}", e.getLocalizedMessage(), e);
         }
     }
 }
+

--- a/src/main/java/edu/self/w2k/command/Command.java
+++ b/src/main/java/edu/self/w2k/command/Command.java
@@ -1,0 +1,5 @@
+package edu.self.w2k.command;
+
+public interface Command {
+    void run() throws Exception;
+}

--- a/src/main/java/edu/self/w2k/command/DownloadCommand.java
+++ b/src/main/java/edu/self/w2k/command/DownloadCommand.java
@@ -1,0 +1,17 @@
+package edu.self.w2k.command;
+
+import edu.self.w2k.download.DumpDownloader;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class DownloadCommand implements Command {
+
+    private final DumpDownloader downloader;
+
+    @Override
+    public void run() {
+        downloader.download();
+    }
+}

--- a/src/main/java/edu/self/w2k/command/GenerateCommand.java
+++ b/src/main/java/edu/self/w2k/command/GenerateCommand.java
@@ -1,0 +1,40 @@
+package edu.self.w2k.command;
+
+import edu.self.w2k.lexicon.LexiconEntry;
+import edu.self.w2k.lexicon.LexiconReader;
+import edu.self.w2k.lexicon.LexiconWriter;
+import edu.self.w2k.opf.OpfGenerator;
+import edu.self.w2k.parse.DictionaryParser;
+import edu.self.w2k.render.DefinitionRenderer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+@Slf4j
+@RequiredArgsConstructor
+public class GenerateCommand implements Command {
+
+    private final DictionaryParser parser;
+    private final DefinitionRenderer renderer;
+    private final LexiconWriter writer;
+    private final LexiconReader reader;
+    private final OpfGenerator generator;
+    private final Path dumpFile;
+    private final Path lexiconFile;
+    private final Path outputDir;
+    private final String lang;
+    private final String title;
+
+    @Override
+    public void run() throws Exception {
+        Stream<LexiconEntry> lexiconEntries = parser.parse(dumpFile, lang)
+                .map(e -> new LexiconEntry(e.getWord(), renderer.render(e.getSenses())))
+                .filter(e -> e.definition() != null);
+
+        writer.write(lexiconFile, lexiconEntries);
+
+        generator.generate(reader.read(lexiconFile), lang, lang, title, outputDir);
+    }
+}

--- a/src/main/java/edu/self/w2k/opf/KindleOpfGenerator.java
+++ b/src/main/java/edu/self/w2k/opf/KindleOpfGenerator.java
@@ -50,7 +50,7 @@ public class KindleOpfGenerator implements OpfGenerator {
      * Builds an auto-generated title from the source and target language codes.
      * Example: {@code "el"} + {@code "en"} → {@code "Modern Greek–English Dictionary"}.
      */
-    static String autoTitle(String srcLang, String trgLang) {
+    public static String autoTitle(String srcLang, String trgLang) {
         String src = Locale.forLanguageTag(srcLang).getDisplayLanguage(Locale.ENGLISH);
         String trg = Locale.forLanguageTag(trgLang).getDisplayLanguage(Locale.ENGLISH);
         // Locale returns the bare tag for unknown codes — uppercase it as a readable fallback.

--- a/src/test/java/edu/self/w2k/command/GenerateCommandTest.java
+++ b/src/test/java/edu/self/w2k/command/GenerateCommandTest.java
@@ -1,0 +1,164 @@
+package edu.self.w2k.command;
+
+import edu.self.w2k.lexicon.TsvLexiconReader;
+import edu.self.w2k.lexicon.TsvLexiconWriter;
+import edu.self.w2k.opf.KindleOpfGenerator;
+import edu.self.w2k.parse.JsonlDictionaryParser;
+import edu.self.w2k.render.HtmlDefinitionRenderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.BufferedWriter;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.zip.GZIPOutputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GenerateCommandTest {
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private static Path writeGzipJsonl(Path dir, List<String> lines) throws IOException {
+        Path gzip = dir.resolve("dump.jsonl.gz");
+        try (GZIPOutputStream gz = new GZIPOutputStream(new FileOutputStream(gzip.toFile()));
+             BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(gz, StandardCharsets.UTF_8))) {
+            for (String line : lines) {
+                bw.write(line);
+                bw.newLine();
+            }
+        }
+        return gzip;
+    }
+
+    private static GenerateCommand buildCommand(Path dumpFile, Path lexiconFile,
+                                                Path outputDir, String lang) {
+        return new GenerateCommand(
+                new JsonlDictionaryParser(),
+                new HtmlDefinitionRenderer(),
+                new TsvLexiconWriter(),
+                new TsvLexiconReader(),
+                new KindleOpfGenerator(),
+                dumpFile,
+                lexiconFile,
+                outputDir,
+                lang,
+                KindleOpfGenerator.autoTitle(lang, lang)
+        );
+    }
+
+    // ── tests ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void run_jsonlDumpToOpf(@TempDir Path tempDir) throws Exception {
+        Path dump = writeGzipJsonl(tempDir, List.of(
+                "{\"word\":\"hello\",\"lang_code\":\"en\",\"senses\":[{\"glosses\":[\"a greeting\"],\"examples\":[{\"text\":\"Hello, world!\"}]}]}",
+                "{\"word\":\"world\",\"lang_code\":\"en\",\"senses\":[{\"glosses\":[\"the earth\"],\"examples\":[]}]}"
+        ));
+        Path lexicon = tempDir.resolve("lexicon.txt");
+
+        buildCommand(dump, lexicon, tempDir, "en").run();
+
+        assertTrue(Files.exists(tempDir.resolve("dictionary-en-en-0.html")), "HTML file must be created");
+        assertTrue(Files.exists(tempDir.resolve("dictionary-en-en.opf")), "OPF file must be created");
+    }
+
+    @Test
+    void run_langFilteringApplied(@TempDir Path tempDir) throws Exception {
+        Path dump = writeGzipJsonl(tempDir, List.of(
+                "{\"word\":\"hello\",\"lang_code\":\"en\",\"senses\":[{\"glosses\":[\"a greeting\"],\"examples\":[]}]}",
+                "{\"word\":\"Hund\",\"lang_code\":\"de\",\"senses\":[{\"glosses\":[\"dog\"],\"examples\":[]}]}",
+                "{\"word\":\"gato\",\"lang_code\":\"es\",\"senses\":[{\"glosses\":[\"cat\"],\"examples\":[]}]}"
+        ));
+        Path lexicon = tempDir.resolve("lexicon.txt");
+
+        buildCommand(dump, lexicon, tempDir, "en").run();
+
+        String html = Files.readString(tempDir.resolve("dictionary-en-en-0.html"), StandardCharsets.UTF_8);
+        assertTrue(html.contains("hello"), "English entry must appear in output");
+        assertFalse(html.contains("Hund"), "German entry must be excluded");
+        assertFalse(html.contains("gato"), "Spanish entry must be excluded");
+    }
+
+    @Test
+    void run_definitionContentPreserved(@TempDir Path tempDir) throws Exception {
+        Path dump = writeGzipJsonl(tempDir, List.of(
+                "{\"word\":\"run\",\"lang_code\":\"en\",\"senses\":[{\"glosses\":[\"move at speed\"],\"examples\":[{\"text\":\"She runs every morning.\"}]}]}"
+        ));
+        Path lexicon = tempDir.resolve("lexicon.txt");
+
+        buildCommand(dump, lexicon, tempDir, "en").run();
+
+        String html = Files.readString(tempDir.resolve("dictionary-en-en-0.html"), StandardCharsets.UTF_8);
+        assertTrue(html.contains("move at speed"), "gloss must appear in HTML");
+        assertTrue(html.contains("She runs every morning."), "example must appear in HTML");
+    }
+
+    @Test
+    void run_formOfEntriesExcluded(@TempDir Path tempDir) throws Exception {
+        Path dump = writeGzipJsonl(tempDir, List.of(
+                "{\"word\":\"ran\",\"lang_code\":\"en\",\"senses\":[{\"form_of\":[{\"word\":\"run\"}]}]}",
+                "{\"word\":\"run\",\"lang_code\":\"en\",\"senses\":[{\"glosses\":[\"to move fast\"],\"examples\":[]}]}"
+        ));
+        Path lexicon = tempDir.resolve("lexicon.txt");
+
+        buildCommand(dump, lexicon, tempDir, "en").run();
+
+        String html = Files.readString(tempDir.resolve("dictionary-en-en-0.html"), StandardCharsets.UTF_8);
+        assertTrue(html.contains("value=\"run\""), "base form must appear");
+        assertFalse(html.contains("value=\"ran\""), "form_of entry must be excluded");
+    }
+
+    @Test
+    void run_xmlSpecialCharsEscaped(@TempDir Path tempDir) throws Exception {
+        Path dump = writeGzipJsonl(tempDir, List.of(
+                "{\"word\":\"ampersand\",\"lang_code\":\"en\",\"senses\":[{\"glosses\":[\"bread & butter\"],\"examples\":[]}]}"
+        ));
+        Path lexicon = tempDir.resolve("lexicon.txt");
+
+        buildCommand(dump, lexicon, tempDir, "en").run();
+
+        String html = Files.readString(tempDir.resolve("dictionary-en-en-0.html"), StandardCharsets.UTF_8);
+        assertTrue(html.contains("bread &amp; butter"), "& must be XML-escaped in HTML");
+        assertFalse(html.contains("bread & butter"), "unescaped & must not appear in HTML");
+    }
+
+    @Test
+    void run_entriesAreSortedInOutput(@TempDir Path tempDir) throws Exception {
+        Path dump = writeGzipJsonl(tempDir, List.of(
+                "{\"word\":\"zebra\",\"lang_code\":\"en\",\"senses\":[{\"glosses\":[\"striped animal\"],\"examples\":[]}]}",
+                "{\"word\":\"apple\",\"lang_code\":\"en\",\"senses\":[{\"glosses\":[\"fruit\"],\"examples\":[]}]}",
+                "{\"word\":\"mango\",\"lang_code\":\"en\",\"senses\":[{\"glosses\":[\"tropical fruit\"],\"examples\":[]}]}"
+        ));
+        Path lexicon = tempDir.resolve("lexicon.txt");
+
+        buildCommand(dump, lexicon, tempDir, "en").run();
+
+        String html = Files.readString(tempDir.resolve("dictionary-en-en-0.html"), StandardCharsets.UTF_8);
+        int applePos = html.indexOf("value=\"apple\"");
+        int mangoPos = html.indexOf("value=\"mango\"");
+        int zebraPos = html.indexOf("value=\"zebra\"");
+
+        assertTrue(applePos < mangoPos, "apple must precede mango in output");
+        assertTrue(mangoPos < zebraPos, "mango must precede zebra in output");
+    }
+
+    @Test
+    void run_lexiconFileContainsExpectedContent(@TempDir Path tempDir) throws Exception {
+        Path dump = writeGzipJsonl(tempDir, List.of(
+                "{\"word\":\"cat\",\"lang_code\":\"en\",\"senses\":[{\"glosses\":[\"a feline animal\"],\"examples\":[]}]}"
+        ));
+        Path lexicon = tempDir.resolve("lexicon.txt");
+
+        buildCommand(dump, lexicon, tempDir, "en").run();
+
+        String content = Files.readString(lexicon, StandardCharsets.UTF_8);
+        assertTrue(content.contains("cat\t"), "lexicon must contain the word");
+        assertTrue(content.contains("a feline animal"), "lexicon must contain the gloss");
+    }
+}


### PR DESCRIPTION
Closes #27

## Summary

Introduces the `command/` package with a `Command` interface and two implementations:

- **`Command`** — simple interface with `run() throws Exception`
- **`DownloadCommand`** — delegates to `DumpDownloader`
- **`GenerateCommand`** — orchestrates the full generate pipeline: parse → render → write lexicon → read lexicon → generate OPF

**`CLI`** is refactored into a pure composition root: it parses args, instantiates concrete implementations, and dispatches to the appropriate command. No service logic remains in `CLI`.

Also includes prerequisite files (`LexiconReader`/`TsvLexiconReader`, `OpfGenerator`/`KindleOpfGenerator`) needed to wire the pipeline.

## Files created/modified

- `src/main/java/edu/self/w2k/command/Command.java` (new)
- `src/main/java/edu/self/w2k/command/DownloadCommand.java` (new)
- `src/main/java/edu/self/w2k/command/GenerateCommand.java` (new)
- `src/main/java/edu/self/w2k/CLI.java` (refactored)
- `src/test/java/edu/self/w2k/command/GenerateCommandTest.java` (new — migrated from `FullPipelineTest`)
- Also includes: `LexiconReader`, `TsvLexiconReader`, `OpfGenerator`, `KindleOpfGenerator` and their tests

## Tests

83 tests pass (`mvn --no-transfer-progress test`).