### PR TITLE
docs: update README and program-flow for OOP architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Converts a set of Wiktionary entries into a MOBI dictionary usable by a Kindle.
 ## How it works
 
 1. The [kaikki.org](https://kaikki.org) pre-extracted Wiktionary JSONL dump is downloaded. It is produced weekly from the English Wiktionary by [wiktextract](https://github.com/tatuylonen/wiktextract) and includes all languages with Lua templates fully expanded.
-2. Some Java code streams the compressed JSONL, filters entries for the chosen language, and generates a text file in which each line has the following format: `word<TAB>definition`.
-3. [tab2opf](https://github.com/nyg/tab2opf) is used to convert the text file into a set of OPF and HTML files.
+2. The compressed JSONL is streamed and filtered by language. Each entry's senses are rendered into an HTML definition string, and the result is written to `dictionaries/lexicon.txt` as `word<TAB>definition` lines.
+3. `lexicon.txt` is read back, entries are grouped by normalised key, and Kindle-compatible OPF and HTML chunk files are generated directly in `dictionaries/`.
 4. [KindleGen](https://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000765211) is used to convert the OPF and HTML files to a MOBI eBook that can be used as a dictionary by a Kindle.
 
 ## Examples of generated dictionaries
@@ -55,11 +55,7 @@ Filter entries for the language of your choice using its [ISO 639-1](https://en.
 This step writes `dictionaries/lexicon.txt` (one `word<TAB>definition` per line), then generates the Kindle OPF and HTML files directly in `dictionaries/`.
 
 ```sh
-# Source language only — target defaults to English, title is auto-generated
 java -jar target/wiktionary-to-kindle-1.0.0.jar generate el
-
-# With explicit target language and custom title
-java -jar target/wiktionary-to-kindle-1.0.0.jar generate el en "Greek–English Dictionary"
 ```
 
 ### 5. Convert the OPF into a MOBI eBook
@@ -82,15 +78,6 @@ cd dictionaries
 ### 6. Upload the file to your Kindle
 
 If all went well, you should now have the `dictionary-el-en.mobi` file in your possession. You can either send it to your Kindle via its Kindle email address, or drag and drop it as you would with another eBook.
-
-## Known limitations
-
-* Entries that are purely `form_of` / `alt_of` references (no `glosses` in the kaikki data) are skipped. Kindle lookups for some inflected forms may therefore not find an entry. Base forms are always included.
-
-## TODO
-
-1. tab2opf should output EPUB v2 or v3 if supported by kindlegen
-	* Finding how to properly structure the OPF entries (inflected terms, etc.).
 
 ## Screenshots
 

--- a/docs/program-flow.md
+++ b/docs/program-flow.md
@@ -8,10 +8,18 @@ sequenceDiagram
         participant CLI
     end
 
-    box Utilities
-        participant DumpUtil
-        participant WiktionaryUtil
-        participant OpfUtil
+    box Commands
+        participant DownloadCommand
+        participant GenerateCommand
+    end
+
+    box Services
+        participant KaikkiDumpDownloader
+        participant JsonlDictionaryParser
+        participant HtmlDefinitionRenderer
+        participant TsvLexiconWriter
+        participant TsvLexiconReader
+        participant KindleOpfGenerator
     end
 
     participant kaikki.org
@@ -20,58 +28,73 @@ sequenceDiagram
     %% ── download command ──────────────────────────────────────────────────────
     User->>CLI: java -jar ... download
 
-    CLI->>DumpUtil: download()
-    DumpUtil->>FileSystem: exists(dumps/raw-wiktextract-data.jsonl.gz)?
+    CLI->>DownloadCommand: run()
+    DownloadCommand->>KaikkiDumpDownloader: download()
+    KaikkiDumpDownloader->>FileSystem: exists(dumps/raw-wiktextract-data.jsonl.gz)?
 
     alt file already exists
-        FileSystem-->>DumpUtil: true
-        DumpUtil-->>CLI: skip (log info)
+        FileSystem-->>KaikkiDumpDownloader: true
+        KaikkiDumpDownloader-->>DownloadCommand: skip (log info)
     else file not present
-        FileSystem-->>DumpUtil: false
-        DumpUtil->>kaikki.org: GET /dictionary/raw-wiktextract-data.jsonl.gz
-        kaikki.org-->>DumpUtil: 200 OK (stream)
-        DumpUtil->>FileSystem: write to .part file
-        DumpUtil->>FileSystem: rename .part → dumps/raw-wiktextract-data.jsonl.gz
-        DumpUtil-->>CLI: done
+        FileSystem-->>KaikkiDumpDownloader: false
+        KaikkiDumpDownloader->>kaikki.org: GET /dictionary/raw-wiktextract-data.jsonl.gz
+        kaikki.org-->>KaikkiDumpDownloader: 200 OK (stream)
+        KaikkiDumpDownloader->>FileSystem: write to .part file
+        KaikkiDumpDownloader->>FileSystem: rename .part → dumps/raw-wiktextract-data.jsonl.gz
+        KaikkiDumpDownloader-->>DownloadCommand: done
     end
 
+    DownloadCommand-->>CLI: done
     CLI-->>User: exit
 
     %% ── generate command ──────────────────────────────────────────────────────
-    User->>CLI: java -jar ... generate [srcLang [trgLang [title]]]
+    User->>CLI: java -jar ... generate [lang]
 
-    CLI->>WiktionaryUtil: generateDictionary(srcLang)
-    WiktionaryUtil->>FileSystem: open dumps/raw-wiktextract-data.jsonl.gz (GZIPInputStream)
-    FileSystem-->>WiktionaryUtil: JSONL stream
+    CLI->>GenerateCommand: run()
+
+    GenerateCommand->>JsonlDictionaryParser: parse(dumpFile, lang)
+    JsonlDictionaryParser->>FileSystem: open dumps/raw-wiktextract-data.jsonl.gz (GZIPInputStream)
+    FileSystem-->>JsonlDictionaryParser: JSONL stream
 
     loop for each JSONL line
-        WiktionaryUtil->>WiktionaryUtil: parse WiktionaryEntry (Jackson)
-        WiktionaryUtil->>WiktionaryUtil: filter by lang_code == srcLang
-        WiktionaryUtil->>WiktionaryUtil: buildDefinition(senses) → HTML string
-        WiktionaryUtil->>WiktionaryUtil: skip form_of-only entries (null definition)
+        JsonlDictionaryParser->>JsonlDictionaryParser: parse WiktionaryEntry (Jackson)
+        JsonlDictionaryParser->>JsonlDictionaryParser: filter by lang_code == lang
     end
 
-    WiktionaryUtil->>FileSystem: write dictionaries/lexicon.txt (word TAB HTML)
-    WiktionaryUtil-->>CLI: done
+    JsonlDictionaryParser-->>GenerateCommand: Stream<WiktionaryEntry>
 
-    CLI->>OpfUtil: generateOpf(lexicon, srcLang, trgLang, title, outDir)
-    OpfUtil->>FileSystem: read dictionaries/lexicon.txt
-    OpfUtil->>OpfUtil: readLexicon → TreeMap<normalisedKey, entries>
-    Note over OpfUtil: keys lowercased, " → ', < and > escaped,<br/>same normalised key grouped together
+    loop for each WiktionaryEntry
+        GenerateCommand->>HtmlDefinitionRenderer: render(senses)
+        HtmlDefinitionRenderer-->>GenerateCommand: HTML string (null if form_of-only)
+        GenerateCommand->>GenerateCommand: wrap as LexiconEntry(word, html)
+    end
+
+    GenerateCommand->>TsvLexiconWriter: write(lexiconFile, Stream<LexiconEntry>)
+    TsvLexiconWriter->>FileSystem: write dictionaries/lexicon.txt (word TAB HTML)
+    TsvLexiconWriter-->>GenerateCommand: done
+
+    GenerateCommand->>TsvLexiconReader: read(lexiconFile)
+    TsvLexiconReader->>FileSystem: read dictionaries/lexicon.txt
+    TsvLexiconReader->>TsvLexiconReader: normalise keys (lowercase, " → ', escape < >)
+    TsvLexiconReader->>TsvLexiconReader: group entries by normalised key
+    TsvLexiconReader-->>GenerateCommand: TreeMap<normalisedKey, List<LexiconEntry>>
+
+    GenerateCommand->>KindleOpfGenerator: generate(defs, lang, lang, title, outputDir)
 
     loop for each chunk of ≤10 000 entries
-        OpfUtil->>FileSystem: write dictionary-{src}-{trg}-N.html
-        Note over OpfUtil: idx:entry + idx:orth + strong term + definition
+        KindleOpfGenerator->>FileSystem: write dictionary-{lang}-{lang}-N.html
+        Note over KindleOpfGenerator: idx:entry + idx:orth + strong term + definition
     end
 
-    OpfUtil->>FileSystem: write dictionary-{src}-{trg}.opf
-    Note over OpfUtil: OPF 2.0, UUID dc:identifier,<br/>DictionaryInLanguage / DictionaryOutLanguage,<br/>manifest + spine entries for every HTML file
+    KindleOpfGenerator->>FileSystem: write dictionary-{lang}-{lang}.opf
+    Note over KindleOpfGenerator: OPF 2.0, UUID dc:identifier,<br/>DictionaryInLanguage / DictionaryOutLanguage,<br/>manifest + spine entries for every HTML file
 
-    OpfUtil-->>CLI: done
+    KindleOpfGenerator-->>GenerateCommand: done
+    GenerateCommand-->>CLI: done
     CLI-->>User: exit
 
     %% ── kindlegen (manual step) ───────────────────────────────────────────────
     Note over User,FileSystem: Optional manual step — run kindlegen externally
-    User->>FileSystem: kindlegen dictionaries/dictionary-{src}-{trg}.opf
-    FileSystem-->>User: dictionaries/dictionary-{src}-{trg}.mobi
+    User->>FileSystem: kindlegen dictionaries/dictionary-{lang}-{lang}.opf
+    FileSystem-->>User: dictionaries/dictionary-{lang}-{lang}.mobi
 ```


### PR DESCRIPTION
## What changed

### README.md
- **How it works**: replaced tab2opf reference with description of Java-native OPF generation; updated step descriptions to match current pipeline
- **Generate command**: removed the now-invalid explicit `trgLang` / `title` args example (CLI only accepts a single `[lang]` argument; title is auto-generated)
- **Removed** Known limitations section
- **Removed** TODO section

### docs/program-flow.md
- Rewrote the Mermaid sequence diagram to use the new OOP classes (`DownloadCommand`, `GenerateCommand`, `KaikkiDumpDownloader`, `JsonlDictionaryParser`, `HtmlDefinitionRenderer`, `TsvLexiconWriter`, `TsvLexiconReader`, `KindleOpfGenerator`) instead of the deleted static utility classes