### PR TITLE
docs: fix Mermaid diagram syntax in program-flow

### DIFF
--- a/docs/program-flow.md
+++ b/docs/program-flow.md
@@ -39,8 +39,7 @@ sequenceDiagram
         FileSystem-->>KaikkiDumpDownloader: false
         KaikkiDumpDownloader->>kaikki.org: GET /dictionary/raw-wiktextract-data.jsonl.gz
         kaikki.org-->>KaikkiDumpDownloader: 200 OK (stream)
-        KaikkiDumpDownloader->>FileSystem: write to .part file
-        KaikkiDumpDownloader->>FileSystem: rename .part → dumps/raw-wiktextract-data.jsonl.gz
+        KaikkiDumpDownloader->>FileSystem: write to .part, rename to .jsonl.gz
         KaikkiDumpDownloader-->>DownloadCommand: done
     end
 
@@ -53,48 +52,40 @@ sequenceDiagram
     CLI->>GenerateCommand: run()
 
     GenerateCommand->>JsonlDictionaryParser: parse(dumpFile, lang)
-    JsonlDictionaryParser->>FileSystem: open dumps/raw-wiktextract-data.jsonl.gz (GZIPInputStream)
+    JsonlDictionaryParser->>FileSystem: open raw-wiktextract-data.jsonl.gz
     FileSystem-->>JsonlDictionaryParser: JSONL stream
-
-    loop for each JSONL line
-        JsonlDictionaryParser->>JsonlDictionaryParser: parse WiktionaryEntry (Jackson)
-        JsonlDictionaryParser->>JsonlDictionaryParser: filter by lang_code == lang
-    end
-
-    JsonlDictionaryParser-->>GenerateCommand: Stream<WiktionaryEntry>
+    Note over JsonlDictionaryParser: parse each line, filter by lang_code
+    JsonlDictionaryParser-->>GenerateCommand: Stream of WiktionaryEntry
 
     loop for each WiktionaryEntry
         GenerateCommand->>HtmlDefinitionRenderer: render(senses)
-        HtmlDefinitionRenderer-->>GenerateCommand: HTML string (null if form_of-only)
-        GenerateCommand->>GenerateCommand: wrap as LexiconEntry(word, html)
+        HtmlDefinitionRenderer-->>GenerateCommand: HTML definition string
     end
 
-    GenerateCommand->>TsvLexiconWriter: write(lexiconFile, Stream<LexiconEntry>)
+    GenerateCommand->>TsvLexiconWriter: write(lexiconFile, entries)
     TsvLexiconWriter->>FileSystem: write dictionaries/lexicon.txt (word TAB HTML)
     TsvLexiconWriter-->>GenerateCommand: done
 
     GenerateCommand->>TsvLexiconReader: read(lexiconFile)
     TsvLexiconReader->>FileSystem: read dictionaries/lexicon.txt
-    TsvLexiconReader->>TsvLexiconReader: normalise keys (lowercase, " → ', escape < >)
-    TsvLexiconReader->>TsvLexiconReader: group entries by normalised key
-    TsvLexiconReader-->>GenerateCommand: TreeMap<normalisedKey, List<LexiconEntry>>
+    Note over TsvLexiconReader: normalise keys, group by key
+    TsvLexiconReader-->>GenerateCommand: TreeMap of key to entries
 
-    GenerateCommand->>KindleOpfGenerator: generate(defs, lang, lang, title, outputDir)
+    GenerateCommand->>KindleOpfGenerator: generate(defs, lang, title, outputDir)
 
-    loop for each chunk of ≤10 000 entries
-        KindleOpfGenerator->>FileSystem: write dictionary-{lang}-{lang}-N.html
-        Note over KindleOpfGenerator: idx:entry + idx:orth + strong term + definition
+    loop for each chunk of up to 10000 entries
+        KindleOpfGenerator->>FileSystem: write dictionary-lang-N.html
     end
 
-    KindleOpfGenerator->>FileSystem: write dictionary-{lang}-{lang}.opf
-    Note over KindleOpfGenerator: OPF 2.0, UUID dc:identifier,<br/>DictionaryInLanguage / DictionaryOutLanguage,<br/>manifest + spine entries for every HTML file
+    KindleOpfGenerator->>FileSystem: write dictionary-lang.opf
+    Note over KindleOpfGenerator: OPF 2.0, manifest + spine for every HTML file
 
     KindleOpfGenerator-->>GenerateCommand: done
     GenerateCommand-->>CLI: done
     CLI-->>User: exit
 
     %% ── kindlegen (manual step) ───────────────────────────────────────────────
-    Note over User,FileSystem: Optional manual step — run kindlegen externally
-    User->>FileSystem: kindlegen dictionaries/dictionary-{lang}-{lang}.opf
-    FileSystem-->>User: dictionaries/dictionary-{lang}-{lang}.mobi
+    Note over User,FileSystem: Optional manual step
+    User->>FileSystem: kindlegen dictionaries/dictionary-lang.opf
+    FileSystem-->>User: dictionaries/dictionary-lang.mobi
 ```

--- a/docs/program-flow.md
+++ b/docs/program-flow.md
@@ -1,91 +1,86 @@
 # Program Flow
 
+## Download command
+
 ```mermaid
 sequenceDiagram
     actor User
-
-    box CLI
-        participant CLI
-    end
-
-    box Commands
-        participant DownloadCommand
-        participant GenerateCommand
-    end
-
-    box Services
-        participant KaikkiDumpDownloader
-        participant JsonlDictionaryParser
-        participant HtmlDefinitionRenderer
-        participant TsvLexiconWriter
-        participant TsvLexiconReader
-        participant KindleOpfGenerator
-    end
-
-    participant kaikki.org
+    participant CLI
+    participant DownloadCommand
+    participant KaikkiDumpDownloader
+    participant kaikkiorg as kaikki.org
     participant FileSystem
 
-    %% ── download command ──────────────────────────────────────────────────────
     User->>CLI: java -jar ... download
-
     CLI->>DownloadCommand: run()
     DownloadCommand->>KaikkiDumpDownloader: download()
-    KaikkiDumpDownloader->>FileSystem: exists(dumps/raw-wiktextract-data.jsonl.gz)?
+    KaikkiDumpDownloader->>FileSystem: exists(jsonl.gz)?
 
     alt file already exists
         FileSystem-->>KaikkiDumpDownloader: true
-        KaikkiDumpDownloader-->>DownloadCommand: skip (log info)
+        KaikkiDumpDownloader-->>DownloadCommand: skip
     else file not present
         FileSystem-->>KaikkiDumpDownloader: false
-        KaikkiDumpDownloader->>kaikki.org: GET /dictionary/raw-wiktextract-data.jsonl.gz
-        kaikki.org-->>KaikkiDumpDownloader: 200 OK (stream)
-        KaikkiDumpDownloader->>FileSystem: write to .part, rename to .jsonl.gz
+        KaikkiDumpDownloader->>kaikkiorg: GET raw-wiktextract-data.jsonl.gz
+        kaikkiorg-->>KaikkiDumpDownloader: 200 OK
+        KaikkiDumpDownloader->>FileSystem: write .part file
+        KaikkiDumpDownloader->>FileSystem: rename .part to jsonl.gz
         KaikkiDumpDownloader-->>DownloadCommand: done
     end
 
     DownloadCommand-->>CLI: done
     CLI-->>User: exit
+```
 
-    %% ── generate command ──────────────────────────────────────────────────────
-    User->>CLI: java -jar ... generate [lang]
+## Generate command
 
+```mermaid
+sequenceDiagram
+    actor User
+    participant CLI
+    participant GenerateCommand
+    participant JsonlDictionaryParser
+    participant HtmlDefinitionRenderer
+    participant TsvLexiconWriter
+    participant TsvLexiconReader
+    participant KindleOpfGenerator
+    participant FileSystem
+
+    User->>CLI: java -jar ... generate lang
     CLI->>GenerateCommand: run()
 
     GenerateCommand->>JsonlDictionaryParser: parse(dumpFile, lang)
-    JsonlDictionaryParser->>FileSystem: open raw-wiktextract-data.jsonl.gz
+    JsonlDictionaryParser->>FileSystem: open jsonl.gz
     FileSystem-->>JsonlDictionaryParser: JSONL stream
-    Note over JsonlDictionaryParser: parse each line, filter by lang_code
+    Note over JsonlDictionaryParser: filter by lang_code
     JsonlDictionaryParser-->>GenerateCommand: Stream of WiktionaryEntry
 
     loop for each WiktionaryEntry
         GenerateCommand->>HtmlDefinitionRenderer: render(senses)
-        HtmlDefinitionRenderer-->>GenerateCommand: HTML definition string
+        HtmlDefinitionRenderer-->>GenerateCommand: HTML string
     end
 
     GenerateCommand->>TsvLexiconWriter: write(lexiconFile, entries)
-    TsvLexiconWriter->>FileSystem: write dictionaries/lexicon.txt (word TAB HTML)
+    TsvLexiconWriter->>FileSystem: write lexicon.txt
     TsvLexiconWriter-->>GenerateCommand: done
 
     GenerateCommand->>TsvLexiconReader: read(lexiconFile)
-    TsvLexiconReader->>FileSystem: read dictionaries/lexicon.txt
-    Note over TsvLexiconReader: normalise keys, group by key
-    TsvLexiconReader-->>GenerateCommand: TreeMap of key to entries
+    TsvLexiconReader->>FileSystem: read lexicon.txt
+    Note over TsvLexiconReader: normalise keys, group entries
+    TsvLexiconReader-->>GenerateCommand: grouped definitions
 
     GenerateCommand->>KindleOpfGenerator: generate(defs, lang, title, outputDir)
 
     loop for each chunk of up to 10000 entries
-        KindleOpfGenerator->>FileSystem: write dictionary-lang-N.html
+        KindleOpfGenerator->>FileSystem: write dictionary HTML file
     end
 
-    KindleOpfGenerator->>FileSystem: write dictionary-lang.opf
-    Note over KindleOpfGenerator: OPF 2.0, manifest + spine for every HTML file
-
+    KindleOpfGenerator->>FileSystem: write dictionary OPF file
     KindleOpfGenerator-->>GenerateCommand: done
     GenerateCommand-->>CLI: done
     CLI-->>User: exit
 
-    %% ── kindlegen (manual step) ───────────────────────────────────────────────
-    Note over User,FileSystem: Optional manual step
-    User->>FileSystem: kindlegen dictionaries/dictionary-lang.opf
-    FileSystem-->>User: dictionaries/dictionary-lang.mobi
+    Note over User,FileSystem: Manual step
+    User->>FileSystem: kindlegen dictionary.opf
+    FileSystem-->>User: dictionary.mobi
 ```


### PR DESCRIPTION
Fixes the rendering error in `docs/program-flow.md` introduced in #38.

Removed characters that break GitHub's Mermaid renderer:
- Angle brackets in generic type labels (`Stream<X>`, `TreeMap<K,V>`)
- Unicode arrows and `≤` character
- Self-referential arrows inside loops
- Curly-brace placeholders in file path labels