### PR TITLE
test: rewrite test suite with Mockito + AssertJ

### DIFF
--- a/docs/test-rewrite-plan.md
+++ b/docs/test-rewrite-plan.md
@@ -1,0 +1,332 @@
+# Test Suite Rewrite Plan
+
+## Context
+
+The current test suite in `src/test/java/edu/self/w2k/` was written using only JUnit Jupiter primitives (`assertEquals`, `assertTrue`, `assertThrows`), with hand-written stub classes instead of a mocking framework. Several test files (`GenerateCommandTest`, `JsonlDictionaryParserTest`, `OpfDictionaryWriterTest`) read or write real files end-to-end and behave more like integration tests than unit tests.
+
+The goal is a **complete rewrite** producing a uniform, modern unit-test suite that:
+- uses Mockito for mocks (no hand-written stubs);
+- uses AssertJ for fluent assertions;
+- treats each production class in isolation (collaborators mocked or replaced with `@TempDir` fixtures for filesystem-bound classes);
+- follows a strict naming + structure convention (`should_..._when_...` + `// Given // When // Then` blocks).
+
+This plan is to be implemented by Sonnet 4.6.
+
+## Hard constraints (from the user)
+
+1. **Mockito** with `@ExtendWith(MockitoExtension.class)` — no manual stubs.
+2. The variable holding the class under test must be named **`unit`**.
+3. **AssertJ** for all assertions, using current idioms (`assertThat(...)`, chained matchers like `containsExactly`, `hasSize`, `isInstanceOf`, `extracting`, etc.).
+4. **JUnit 6** (`junit-jupiter` 6.0.3 — already on the classpath).
+5. Test method name pattern: **`should_<expectation>_when_<condition>`**.
+6. Each test body is split with **`// Given`**, **`// When`**, **`// Then`** comments.
+7. Tests should be **straightforward** — no clever helper hierarchies.
+8. **Happy path + main alternative path only** — no exhaustive branch coverage.
+9. **Never use `var`** — always declare explicit types.
+10. Unit tests only — no integration or e2e tests.
+
+## Dependencies to add to `pom.xml`
+
+Add to `<properties>` block:
+```xml
+<assertj-core.version>3.27.7</assertj-core.version>
+<mockito.version>5.21.0</mockito.version>
+```
+(use the latest stable releases at implementation time)
+
+Add to `<dependencies>` block (both `<scope>test</scope>`):
+```xml
+<dependency>
+    <groupId>org.assertj</groupId>
+    <artifactId>assertj-core</artifactId>
+    <version>${assertj-core.version}</version>
+    <scope>test</scope>
+</dependency>
+<dependency>
+    <groupId>org.mockito</groupId>
+    <artifactId>mockito-core</artifactId>
+    <version>${mockito.version}</version>
+    <scope>test</scope>
+</dependency>
+<dependency>
+    <groupId>org.mockito</groupId>
+    <artifactId>mockito-junit-jupiter</artifactId>
+    <version>${mockito.version}</version>
+    <scope>test</scope>
+</dependency>
+```
+
+## Production refactor required
+
+`src/main/java/edu/self/w2k/download/KaikkiDumpDownloader.java` currently builds its `HttpClient` inside `download()`, making the method untestable without real network. Mirror the pattern already used in `KindlingDownloader` (public constructor + package-private constructor for tests):
+
+- Keep the public constructor `public KaikkiDumpDownloader(String lang)` that internally builds the default `HttpClient`.
+- Add a package-private constructor `KaikkiDumpDownloader(String lang, HttpClient httpClient)` and store the client in a final field.
+- Have `download()` use that field instead of building a fresh client.
+
+Also (recommended) extract `DUMPS_DIR` so it can be passed in for tests, **or** scope file-system writes inside an injectable `Path baseDir` second constructor parameter. Simplest: accept a `Path dumpsDir` alongside `HttpClient` in the package-private constructor.
+
+No other production changes are required.
+
+## Files to delete
+
+Delete every existing test file under `src/test/java/edu/self/w2k/`:
+
+```
+src/test/java/edu/self/w2k/command/GenerateCommandTest.java
+src/test/java/edu/self/w2k/kindling/KindlingCliResolverTest.java
+src/test/java/edu/self/w2k/kindling/KindlingDictionaryConverterTest.java
+src/test/java/edu/self/w2k/kindling/KindlingDownloaderTest.java
+src/test/java/edu/self/w2k/kindling/KindlingPlatformTest.java
+src/test/java/edu/self/w2k/kindling/XdgCachePathsTest.java
+src/test/java/edu/self/w2k/parse/JsonlDictionaryParserTest.java
+src/test/java/edu/self/w2k/render/HtmlDefinitionRendererTest.java
+src/test/java/edu/self/w2k/write/DictionaryTitlesTest.java
+src/test/java/edu/self/w2k/write/opf/HtmlChapterRendererTest.java
+src/test/java/edu/self/w2k/write/opf/OpfDictionaryWriterTest.java
+```
+
+## Skipped from testing (deliberate)
+
+These classes have no logic worth covering in a unit suite:
+
+- `CLI` — picocli wiring + `main`. Hard-codes `Path.of("dumps")`; leave as integration territory.
+- `KindlingException` — exception class with two delegating constructors.
+- `KindlingRelease` — static data holder.
+- All records: `LexiconEntry`, `WiktionaryEntry`, `WiktionarySense`, `WiktionaryExample`.
+- All interfaces: `Command`, `DumpDownloader`, `DictionaryParser`, `DefinitionRenderer`, `DictionaryWriter`, `HttpFetcher`.
+- `KindlingDictionaryConverter.defaultRunner()` — wraps `ProcessBuilder` directly; not unit-testable without spawning a process.
+
+## Test class template
+
+Every new test file follows this exact skeleton (no exceptions, no var):
+
+```java
+package edu.self.w2k.<package>;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class <ClassName>Test {
+
+    @Mock
+    private <Collaborator> collaborator;
+
+    @InjectMocks
+    private <ClassName> unit;          // when constructor injection works
+
+    // OR, when collaborators must be wired manually (e.g. value params):
+    // private <ClassName> unit;
+    // @BeforeEach void setUp() { unit = new <ClassName>(...); }
+
+    @Test
+    void should_<expectation>_when_<condition>() {
+        // Given
+        ...
+
+        // When
+        ...
+
+        // Then
+        assertThat(...)...;
+    }
+}
+```
+
+When the production class is package-private (e.g. `HtmlChapterRenderer`) the test must live in the matching package and stay package-private.
+
+## New test files (per package)
+
+### `src/test/java/edu/self/w2k/command/`
+
+#### `DownloadCommandTest.java`
+- Collaborators: `@Mock DumpDownloader downloader;` `@InjectMocks DownloadCommand unit;`
+- `should_invoke_downloader_when_run_is_called` — call `unit.run()`; verify `downloader.download()` was called exactly once.
+
+#### `GenerateCommandTest.java`
+- Collaborators: `@Mock DictionaryParser parser; @Mock DefinitionRenderer renderer; @Mock DictionaryWriter writer;` plus `@TempDir Path tmp;` for the dump path argument (file does not need real content because the parser is mocked).
+- `unit` built manually in `@BeforeEach` because `GenerateCommand` has many primitive params.
+- `should_group_entries_and_write_dictionary_when_run` — happy path:
+  - stub `parser.parse(any(), eq(srcLang))` to return `Stream.of(new WiktionaryEntry("Apple", srcLang, List.of(...)), new WiktionaryEntry("apple", srcLang, ...), new WiktionaryEntry("banana", srcLang, ...))`;
+  - stub `renderer.render(any())` to return `Optional.of("<def>")`;
+  - call `unit.run()`;
+  - capture the `TreeMap<String, List<LexiconEntry>>` argument passed to `writer.write(...)` via `ArgumentCaptor`;
+  - assert: keys are normalised + sorted (`assertThat(captured).containsKeys("apple", "banana")`); duplicate keys merged into a list (`assertThat(captured.get("apple")).hasSize(2)`); writer received the right `srcLang`, `trgLang`, `title`, `outputDir`.
+- `should_skip_entries_when_renderer_returns_empty` — alternative path:
+  - stub renderer to return `Optional.empty()` for one of two entries;
+  - assert the captured map only contains the surviving entry.
+
+For `GenerateCommand.normaliseKey(String)` (package-private static, in the same test class as `@Nested` block or two extra `@Test` methods):
+- `should_lowercase_and_strip_when_normalising_key` — `"  Hello  "` → `"hello"`.
+- `should_replace_quotes_and_escape_angle_brackets_when_normalising_key` — `"\"<a>\""` → `"'\\<a\\>'"`.
+
+### `src/test/java/edu/self/w2k/download/`
+
+#### `KaikkiDumpDownloaderTest.java`
+- Collaborators: `@Mock HttpClient httpClient;` `@TempDir Path tmp;` (passed as the dumps directory through the new package-private constructor).
+- `should_save_dump_with_date_when_download_succeeds` — happy path:
+  - mock an `HttpResponse<Path>` returning status 200, header `last-modified: Fri, 01 May 2026 10:00:00 GMT` (**note**: JDK 25 `RFC_1123_DATE_TIME` does not parse leniently when the day-of-week mismatches the date, so use the correct weekday — May 1 2026 is a Friday), body path = part file (pre-create the part file in `tmp`);
+  - use `doAnswer` to write an empty byte array to `partPath` (with `Files.write`) and return the mock response — `Files.createFile` would fail if `BodyHandlers.ofFile` already opened the file on JDK 25;
+  - run `unit.download()`;
+  - assert: `tmp.resolve("raw-wiktextract-data-en-2026-05-01.jsonl.gz")` exists; the `.part` file no longer exists.
+- `should_keep_existing_dump_when_target_already_exists` — alternative path:
+  - pre-create the destination file `raw-wiktextract-data-en-2026-05-01.jsonl.gz` in `tmp`;
+  - run `download()`;
+  - assert: the existing file is untouched and any `.part` file has been cleaned up.
+
+For `KaikkiDumpDownloader.buildUrl(String)` (package-private static):
+- `should_use_dictionary_path_when_lang_is_english` — `buildUrl("en")` ends with `/dictionary/raw-wiktextract-data.jsonl.gz`.
+- `should_use_lang_wiktionary_path_when_lang_is_other` — `buildUrl("fr")` ends with `/frwiktionary/raw-wiktextract-data.jsonl.gz`.
+
+### `src/test/java/edu/self/w2k/kindling/`
+
+#### `KindlingPlatformTest.java`
+- No mocks; pure static `detect(osName, arch)`.
+- `should_return_linux_x64_when_os_is_linux_amd64` — `detect("Linux", "amd64")` returns `LINUX_X64` and `assetName()` is `"kindling-cli-linux"`.
+- `should_throw_when_platform_is_unsupported` — `detect("SunOS", "sparc")` throws `KindlingException` (use `assertThatThrownBy`).
+
+#### `XdgCachePathsTest.java`
+- No mocks; pure static `kindlingCacheDir(env, osName)`.
+- `should_use_xdg_cache_home_when_set_on_unix` — env `XDG_CACHE_HOME=/c`, `os.name="Linux"` → `/c/wiktionary-to-kindle/kindling`.
+- `should_fallback_to_home_when_xdg_is_unset_on_unix` — env `HOME=/h`, no `XDG_CACHE_HOME` → `/h/.cache/wiktionary-to-kindle/kindling`.
+- `should_use_localappdata_when_set_on_windows` — env `LOCALAPPDATA=C:\local`, `os.name="Windows 10"` → `C:\local\wiktionary-to-kindle\Cache\kindling`.
+
+#### `KindlingDownloaderTest.java`
+- Collaborators: `@Mock HttpFetcher fetcher;` `unit` built manually with the package-private `KindlingDownloader(HttpFetcher)` constructor; `@TempDir Path destDir;`.
+- `should_download_and_return_final_path_when_sha256_matches` — happy path:
+  - choose payload bytes, compute their SHA-256 with `MessageDigest`, build a release with `KindlingPlatform.LINUX_X64` whose digest equals that hash (use `KindlingRelease.DEFAULT_VERSION` to hit the `DEFAULT_ASSETS` branch — but its hardcoded digest will not match arbitrary bytes, so the test must use a non-default version and stub `fetcher.getString` to return JSON containing the matching digest);
+  - stub `fetcher.getFile(any(), any())` to write payload bytes to the part path and return it;
+  - call `unit.download(...)`;
+  - assert: returned path equals `destDir.resolve(platform.assetName())`; file exists; part file gone.
+- `should_throw_when_sha256_mismatch` — alternative:
+  - stub fetcher to return bytes that don't match;
+  - assert `assertThatThrownBy(() -> unit.download(...)).isInstanceOf(KindlingException.class).hasMessageContaining("SHA-256 mismatch")`;
+  - assert the downloaded file was deleted.
+
+#### `KindlingCliResolverTest.java`
+- Collaborators: `@Mock KindlingDownloader downloader;` `@Mock Function<String, Optional<Path>> pathProbe;` `@Mock BiFunction<String, KindlingPlatform, String> digestProvider;` `@TempDir Path cache;`
+- `unit` constructed manually using the package-private 5-arg constructor in `@BeforeEach`. The override and version are per-test (use a setter helper or rebuild `unit`).
+- `should_return_override_when_override_is_executable` — happy path A:
+  - create an executable file in `tmp`, build `unit` with `Optional.of(executable)`;
+  - call `resolve()`;
+  - assert returned path equals the executable; verify the downloader was never called.
+- `should_return_path_binary_when_found_on_path` — happy path B:
+  - stub `pathProbe.apply("kindling-cli")` to return an executable path;
+  - assert that path is returned; downloader never called.
+- `should_download_when_cache_is_empty` — alternative:
+  - stub `pathProbe.apply(...)` to return `Optional.empty()`;
+  - stub `downloader.download(any(), any(), any())` to return a path under `cache`;
+  - assert the returned path; verify `downloader.download(...)` called once.
+
+(`KindlingCliResolver.resolveFromCacheOrDownload` reads `XdgCachePaths.kindlingCacheDir()` directly, which depends on real env vars. The third test should rely on the override / PATH branches OR set `XDG_CACHE_HOME` via `System.setProperty` is not possible — XDG comes from `System.getenv()`. **Workaround**: in the third test, leave the cache empty so the production goes straight to the downloader (which is mocked) — we don't need to control where the cache lives, only that the file isn't there. If tests on contributors' machines could find a real cached binary, gate by mocking `pathProbe` and asserting `downloader.download` was invoked irrespective of the actual cache path.)
+
+#### `KindlingDictionaryConverterTest.java`
+- Collaborators: `@Mock OpfDictionaryWriter opfWriter; @Mock KindlingCliResolver resolver; @Mock ProcessRunner runner;` `@InjectMocks KindlingDictionaryConverter unit;` `@TempDir Path outputDir;`
+- `should_run_kindling_cli_and_return_mobi_path_when_write` — happy path:
+  - stub `opfWriter.write(any(), eq("en"), eq("fr"), eq("Title"), eq(outputDir))` to return `outputDir.resolve("dictionary-en-fr.opf")`;
+  - stub `resolver.resolve()` to return `outputDir.resolve("kindling-cli")`;
+  - stub `runner.run(anyList())` to return 0;
+  - call `unit.write(new TreeMap<>(), "en", "fr", "Title", outputDir)`;
+  - assert returned path equals `outputDir.resolve("dictionary-en-fr.mobi")`;
+  - capture the runner's `List<String> command` and assert it contains `"build"`, the OPF path, `"-o"`, the MOBI path.
+- `should_throw_io_exception_when_runner_returns_non_zero_exit_code` — alternative:
+  - stub `runner.run(anyList())` to return 1;
+  - `assertThatThrownBy(...).isInstanceOf(IOException.class).hasMessageContaining("exit")`.
+
+### `src/test/java/edu/self/w2k/parse/`
+
+#### `JsonlDictionaryParserTest.java`
+- Collaborators: `@TempDir Path tmp;` plus `JsonlDictionaryParser unit = new JsonlDictionaryParser();` (no Mockito needed beyond the extension annotation, but apply it for consistency).
+- Helper: write a small gzipped JSONL file into `tmp` from a string literal containing 2-3 entries.
+- `should_return_only_entries_matching_lang_when_parsing` — happy path: dump contains one `el` and one `en` entry; parse with `lang="el"`; collect stream; assert `extracting(WiktionaryEntry::word).containsExactly("γεια")`.
+- `should_skip_entries_with_blank_word_when_parsing` — alternative: dump contains an entry with empty word; assert it is filtered out.
+
+### `src/test/java/edu/self/w2k/render/`
+
+#### `HtmlDefinitionRendererTest.java`
+- `HtmlDefinitionRenderer unit = new HtmlDefinitionRenderer();`
+- `should_render_html_with_glosses_and_examples_when_senses_have_content` — happy: build `WiktionarySense` records directly (no Jackson), call `unit.render(...)`, assert HTML contains `<ol>`, `<li><span>...`, an `<ul>` with example items, ends with `</ol>`.
+- `should_return_empty_when_no_glosses_have_content` — alternative: senses with empty/blank/null glosses → `assertThat(unit.render(...)).isEmpty()`.
+
+(Replace the third existing escape-test by folding XML escaping + newline replacement into the happy-path assertion using AssertJ's `contains(...)` chained matcher: `assertThat(html).contains("&amp;").contains("; ").doesNotContain("\n");`)
+
+### `src/test/java/edu/self/w2k/write/`
+
+#### `DictionaryTitlesTest.java`
+- No mocks; pure static `autoTitle(srcLang, trgLang)`.
+- `should_use_display_names_when_lang_codes_are_known` — `autoTitle("el","en")` → `"Modern Greek–English Dictionary"` (or whatever JDK 25 returns for `el`; assert via `contains("Greek")` and `contains("English")` and `contains("–")` to avoid JDK locale flakiness).
+- `should_uppercase_when_lang_code_is_unknown` — `autoTitle("xx","yy")` → starts with `"XX"` ends with `"Dictionary"`.
+
+### `src/test/java/edu/self/w2k/write/opf/`
+
+#### `HtmlChapterRendererTest.java` (package-private)
+- No mocks.
+- `should_render_kindle_idx_entries_when_called` — happy: pass a 2-entry list; assert the resulting `String` (`new String(bytes, UTF_8)`) contains `xmlns:idx`, `xmlns:mbp`, `<idx:entry name="word"`, `<idx:orth value="apple">`, `<b>apple</b>`.
+- `should_combine_definitions_with_semicolons_when_multiple_entries_share_key` — alternative: pass a single key with two `LexiconEntry` values; assert the combined HTML contains `def1; def2`.
+
+#### `OpfDictionaryWriterTest.java`
+- `OpfDictionaryWriter unit = new OpfDictionaryWriter();` `@TempDir Path tmp;`
+- `should_write_opf_html_and_return_opf_path_when_called` — happy: 3 entries → assert returned path is `tmp.resolve("dictionary-en-fr.opf")`; assert that file exists; read contents and assert they contain `<DictionaryInLanguage>en</DictionaryInLanguage>` and `<DictionaryOutLanguage>fr</DictionaryOutLanguage>`; assert `dictionary-en-fr-0.html` was also written.
+- `should_chunk_html_files_when_entries_exceed_chapter_limit` — alternative: build a `TreeMap` with `HtmlChapterRenderer.ENTRIES_PER_CHAPTER + 1` entries (10 001); assert `dictionary-en-fr-0.html` and `dictionary-en-fr-1.html` both exist.
+
+## AssertJ idioms to apply (avoid old-JUnit habits)
+
+- `assertThat(map).containsKeys("apple")` instead of `assertTrue(map.containsKey(...))`.
+- `assertThat(list).hasSize(2).extracting(LexiconEntry::word).containsExactly("a", "b")`.
+- `assertThat(html).contains(...).doesNotContain(...)` chained.
+- `assertThatThrownBy(() -> unit.x()).isInstanceOf(KindlingException.class).hasMessageContaining("SHA-256")`.
+- `assertThat(path).exists().isRegularFile()`.
+- `assertThat(optional).isPresent().contains(value)` / `.isEmpty()`.
+
+## Mockito idioms to apply
+
+- `@Mock` + `@InjectMocks` whenever the target's constructor lets Mockito wire collaborators.
+- For services with many primitive parameters (e.g. `GenerateCommand`), drop `@InjectMocks` and instantiate manually in `@BeforeEach`.
+- Use `ArgumentCaptor` for verifying complex arguments (e.g. the `TreeMap` passed to `DictionaryWriter.write`).
+- Prefer `verify(mock).method(...)` over `verify(mock, times(1)).method(...)` (defaults to once).
+- Avoid `verifyNoMoreInteractions` unless it adds value — keeps tests resilient to refactors.
+- Don't use `@Spy` unless absolutely required; this codebase has no place that needs it.
+
+## Implementation order
+
+1. Update `pom.xml` (Mockito + AssertJ properties + dependencies).
+2. Refactor `KaikkiDumpDownloader` to inject `HttpClient` (and `Path dumpsDir`) via package-private constructor.
+3. Delete every existing test file listed above.
+4. Add new test files in this order (so each layer's tests compile against already-mocked dependencies — order doesn't strictly matter since collaborators are mocked, but it helps locally validate progress):
+   1. Pure-logic / static-only: `KindlingPlatformTest`, `XdgCachePathsTest`, `DictionaryTitlesTest`, `HtmlChapterRendererTest`, `HtmlDefinitionRendererTest`.
+   2. Mockito-only: `DownloadCommandTest`, `KindlingDictionaryConverterTest`, `KindlingDownloaderTest`, `KindlingCliResolverTest`, `GenerateCommandTest`.
+   3. `@TempDir`-based: `JsonlDictionaryParserTest`, `OpfDictionaryWriterTest`, `KaikkiDumpDownloaderTest`.
+5. Run `mvn test` after each batch and fix compile/test failures before continuing.
+
+## Verification
+
+```sh
+mvn clean test          # all tests must pass
+mvn package             # full build with shade still works
+```
+
+End-to-end smoke check (manual, optional, not part of the unit suite):
+```sh
+java -jar target/wiktionary-to-kindle-1.0.0.jar download fr
+java -jar target/wiktionary-to-kindle-1.0.0.jar generate fr en
+```
+
+## Critical files to reference during implementation
+
+| File | Purpose |
+|------|---------|
+| `pom.xml` | add Mockito + AssertJ deps |
+| `src/main/java/edu/self/w2k/download/KaikkiDumpDownloader.java` | add package-private constructor |
+| `src/main/java/edu/self/w2k/kindling/KindlingDownloader.java` | reference pattern for HttpFetcher injection |
+| `src/main/java/edu/self/w2k/kindling/KindlingCliResolver.java` | reference for the package-private testing constructor pattern |
+| `src/main/java/edu/self/w2k/command/GenerateCommand.java` | the orchestrator whose flow the captor-based test exercises |
+| `src/main/java/edu/self/w2k/write/opf/HtmlChapterRenderer.java` | package-private — test must live in the same package |

--- a/docs/unit-testing-rules.md
+++ b/docs/unit-testing-rules.md
@@ -1,0 +1,42 @@
+# Unit Testing Rules
+
+## 1. Framework setup
+
+- Annotate every test class with `@ExtendWith(MockitoExtension.class)`. No manual stub classes.
+- Use **AssertJ** for all assertions: import `assertThat` and `assertThatThrownBy` from `org.assertj.core.api.Assertions`. Never use JUnit's `assertEquals`, `assertTrue`, `assertThrows`, etc.
+- Use **JUnit Jupiter** as the test runner.
+- Write unit tests only — no integration or end-to-end tests.
+
+## 2. Class structure
+
+- The variable holding the class under test must always be named **`unit`**.
+- Use `@InjectMocks private <ClassName> unit;` wherever Mockito can reliably wire the constructor (i.e., when there is exactly one constructor and all its parameters are mockable types). This is the preferred form.
+- When the production class has non-injectable constructor parameters (primitives, `String`, `Path`, etc.), or when ambiguity between constructors would cause Mockito to pick the wrong one, declare `unit` as a **local variable inside `// Given`** — do **not** use `@BeforeEach` for this.
+- Declare mocks of generic types (e.g., `HttpResponse<Path>`) as `@Mock` fields on the class, not as inline `mock(...)` calls inside test methods.
+- No `@BeforeEach` setUp helpers, no private helper methods, no shared constants. Every test must be **self-contained** — inline everything.
+- No `@Spy`. No `var` — always write explicit types.
+
+## 3. Test method structure
+
+- Name pattern: **`should_<expectation>_when_<condition>`**.
+- Split the test body with `// Given`, `// When`, `// Then` comment blocks.
+- **Omit `// Given` entirely** when there is nothing to declare in it. Start directly with `// When`. Never write `// Given / When` or `// Given (no setup needed)`.
+- Cover the **happy path and one main alternative path** only. No exhaustive branch coverage.
+
+## 4. Assertion and verification style
+
+- **Chain `assertThat()` calls** when the subject is the same object:
+  ```java
+  assertThat(result).isEqualTo(expected).exists();   // good
+  assertThat(result).isEqualTo(expected);             // bad — separate call
+  assertThat(result).exists();                        //       on same subject
+  ```
+- Use AssertJ's dedicated predicates — never wrap a boolean in `assertThat(...).isTrue()`:
+  ```java
+  assertThat(str).startsWith("foo");              // good
+  assertThat(str.startsWith("foo")).isTrue();     // bad (Sonar S5785)
+  ```
+- **Avoid `ArgumentCaptor`** unless it is the only practical way to assert on a complex argument.
+- When `ArgumentCaptor` is needed and the type parameter would cause an unchecked warning, use **`ArgumentCaptor.captor()`** instead of `ArgumentCaptor.forClass(...)`. No `@SuppressWarnings("unchecked")` should be needed.
+- Write `verify(mock).method(...)` — the default count is 1, never add `times(1)` explicitly.
+- Avoid `verifyNoMoreInteractions` — it makes tests brittle to unrelated refactors.

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,8 @@
         <picocli.version>4.7.7</picocli.version>
         <slf4j-api.version>2.0.17</slf4j-api.version>
         <junit-jupiter.version>6.0.3</junit-jupiter.version>
+        <assertj-core.version>3.27.7</assertj-core.version>
+        <mockito.version>5.21.0</mockito.version>
 
         <!-- Plugins -->
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
@@ -70,6 +72,24 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj-core.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/edu/self/w2k/CLI.java
+++ b/src/main/java/edu/self/w2k/CLI.java
@@ -1,10 +1,8 @@
 package edu.self.w2k;
 
-import java.net.http.HttpClient;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 
@@ -57,8 +55,7 @@ public class CLI implements Callable<Integer> {
                     latest = path;
                 }
             }
-        }
-        catch (Exception _) {
+        } catch (Exception _) {
             return Optional.empty();
         }
         return Optional.ofNullable(latest);
@@ -124,11 +121,7 @@ public class CLI implements Callable<Integer> {
             }
 
             String title = DictionaryTitles.autoTitle(wordLang, dumpLang);
-            HttpClient httpClient = HttpClient.newBuilder()
-                    .followRedirects(HttpClient.Redirect.NORMAL)
-                    .connectTimeout(Duration.ofSeconds(60))
-                    .build();
-            KindlingDownloader downloader = new KindlingDownloader(httpClient);
+            KindlingDownloader downloader = new KindlingDownloader();
             KindlingCliResolver resolver = new KindlingCliResolver(
                     kindlingVersion, Optional.ofNullable(kindlingCliPath), downloader);
             DictionaryWriter writer = new KindlingDictionaryConverter(

--- a/src/main/java/edu/self/w2k/command/Command.java
+++ b/src/main/java/edu/self/w2k/command/Command.java
@@ -1,5 +1,7 @@
 package edu.self.w2k.command;
 
+import java.io.IOException;
+
 public interface Command {
-    void run() throws Exception;
+    void run() throws IOException;
 }

--- a/src/main/java/edu/self/w2k/command/GenerateCommand.java
+++ b/src/main/java/edu/self/w2k/command/GenerateCommand.java
@@ -1,5 +1,6 @@
 package edu.self.w2k.command;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -29,7 +30,7 @@ public class GenerateCommand implements Command {
     private final String title;
 
     @Override
-    public void run() throws Exception {
+    public void run() throws IOException {
         log.info("Using dump: {}", dumpFile);
         TreeMap<String, List<LexiconEntry>> grouped = new TreeMap<>();
         AtomicLong count = new AtomicLong();

--- a/src/main/java/edu/self/w2k/download/KaikkiDumpDownloader.java
+++ b/src/main/java/edu/self/w2k/download/KaikkiDumpDownloader.java
@@ -11,9 +11,12 @@ import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public class KaikkiDumpDownloader implements DumpDownloader {
 
     private static final String BASE_URL = "https://kaikki.org";
@@ -25,22 +28,18 @@ public class KaikkiDumpDownloader implements DumpDownloader {
 
     public KaikkiDumpDownloader(String lang) {
         this(lang,
-                HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(30)).build(),
-                Path.of("dumps"));
-    }
-
-    KaikkiDumpDownloader(String lang, HttpClient httpClient, Path dumpsDir) {
-        this.lang = lang;
-        this.httpClient = httpClient;
-        this.dumpsDir = dumpsDir;
+             HttpClient.newBuilder()
+                     .followRedirects(HttpClient.Redirect.NORMAL)
+                     .connectTimeout(Duration.ofSeconds(30))
+                     .build(),
+             Path.of("dumps"));
     }
 
     @Override
     public void download() {
         try {
             Files.createDirectories(dumpsDir);
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             log.error("Failed to create dump directory: {}", e.getLocalizedMessage(), e);
             return;
         }
@@ -68,8 +67,7 @@ public class KaikkiDumpDownloader implements DumpDownloader {
                 try {
                     ZonedDateTime parsed = ZonedDateTime.parse(lastModified, DateTimeFormatter.RFC_1123_DATE_TIME);
                     generatedDate = parsed.format(DateTimeFormatter.ISO_LOCAL_DATE);
-                }
-                catch (Exception e) {
+                } catch (Exception e) {
                     generatedDate = lastModified;
                 }
             }
@@ -83,13 +81,11 @@ public class KaikkiDumpDownloader implements DumpDownloader {
 
             Files.move(partPath, dumpPath, StandardCopyOption.REPLACE_EXISTING);
             log.info("Download complete: {} ({} MB, generated: {})", dumpPath, Files.size(dumpPath) / (1024 * 1024), generatedDate);
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             log.error("Download failed: {}", e.getLocalizedMessage(), e);
             try {
                 Files.deleteIfExists(partPath);
-            }
-            catch (Exception nested) {
+            } catch (Exception nested) {
                 log.warn("Failed to delete partial file", nested);
             }
         }

--- a/src/main/java/edu/self/w2k/download/KaikkiDumpDownloader.java
+++ b/src/main/java/edu/self/w2k/download/KaikkiDumpDownloader.java
@@ -1,7 +1,9 @@
 package edu.self.w2k.download;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.file.Files;
@@ -61,18 +63,8 @@ public class KaikkiDumpDownloader implements DumpDownloader {
                 return;
             }
 
-            String lastModified = response.headers().firstValue("last-modified").orElse(null);
-            String generatedDate = "unknown";
-            if (lastModified != null) {
-                try {
-                    ZonedDateTime parsed = ZonedDateTime.parse(lastModified, DateTimeFormatter.RFC_1123_DATE_TIME);
-                    generatedDate = parsed.format(DateTimeFormatter.ISO_LOCAL_DATE);
-                } catch (Exception e) {
-                    generatedDate = lastModified;
-                }
-            }
-
-            Path dumpPath = dumpsDir.resolve("raw-wiktextract-data-" + lang + "-" + generatedDate + ".jsonl.gz");
+            String generatedDate = buildGeneratedDate(response.headers());
+            Path dumpPath = dumpsDir.resolve("raw-wiktextract-data-%s-%s.jsonl.gz".formatted(lang, generatedDate));
             if (Files.exists(dumpPath)) {
                 log.info("Dump already exists at {}. Delete it to re-download.", dumpPath);
                 Files.deleteIfExists(partPath);
@@ -81,13 +73,32 @@ public class KaikkiDumpDownloader implements DumpDownloader {
 
             Files.move(partPath, dumpPath, StandardCopyOption.REPLACE_EXISTING);
             log.info("Download complete: {} ({} MB, generated: {})", dumpPath, Files.size(dumpPath) / (1024 * 1024), generatedDate);
-        } catch (Exception e) {
-            log.error("Download failed: {}", e.getLocalizedMessage(), e);
+        } catch (InterruptedException _) {
+            Thread.currentThread().interrupt();
+            log.warn("Download interrupted for lang: {}", lang);
+        } catch (IOException e) {
+            log.error("Download failed", e);
+        } finally {
             try {
                 Files.deleteIfExists(partPath);
-            } catch (Exception nested) {
-                log.warn("Failed to delete partial file", nested);
+            } catch (IOException e) {
+                log.warn("Failed to delete partial file", e);
             }
+        }
+    }
+
+    private String buildGeneratedDate(HttpHeaders headers) {
+        String lastModified = headers.firstValue("last-modified").orElse(null);
+        if (lastModified == null) {
+            return "unknown";
+        }
+
+        try {
+            return ZonedDateTime
+                    .parse(lastModified, DateTimeFormatter.RFC_1123_DATE_TIME)
+                    .format(DateTimeFormatter.ISO_LOCAL_DATE);
+        } catch (Exception _) {
+            return lastModified;
         }
     }
 
@@ -98,8 +109,8 @@ public class KaikkiDumpDownloader implements DumpDownloader {
      */
     static String buildUrl(String lang) {
         String path = "en".equals(lang)
-                ? "/dictionary/" + DUMP_FILENAME
-                : "/" + lang + "wiktionary/" + DUMP_FILENAME;
-        return BASE_URL + path;
+                ? "/dictionary/"
+                : "/%swiktionary/".formatted(lang);
+        return BASE_URL + path + DUMP_FILENAME;
     }
 }

--- a/src/main/java/edu/self/w2k/download/KaikkiDumpDownloader.java
+++ b/src/main/java/edu/self/w2k/download/KaikkiDumpDownloader.java
@@ -18,18 +18,27 @@ public class KaikkiDumpDownloader implements DumpDownloader {
 
     private static final String BASE_URL = "https://kaikki.org";
     private static final String DUMP_FILENAME = "raw-wiktextract-data.jsonl.gz";
-    private static final Path DUMPS_DIR = Path.of("dumps");
 
     private final String lang;
+    private final HttpClient httpClient;
+    private final Path dumpsDir;
 
     public KaikkiDumpDownloader(String lang) {
+        this(lang,
+                HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(30)).build(),
+                Path.of("dumps"));
+    }
+
+    KaikkiDumpDownloader(String lang, HttpClient httpClient, Path dumpsDir) {
         this.lang = lang;
+        this.httpClient = httpClient;
+        this.dumpsDir = dumpsDir;
     }
 
     @Override
     public void download() {
         try {
-            Files.createDirectories(DUMPS_DIR);
+            Files.createDirectories(dumpsDir);
         }
         catch (Exception e) {
             log.error("Failed to create dump directory: {}", e.getLocalizedMessage(), e);
@@ -39,17 +48,14 @@ public class KaikkiDumpDownloader implements DumpDownloader {
         String url = buildUrl(lang);
         log.info("Downloading {} (checking headers...)", url);
 
-        Path partPath = DUMPS_DIR.resolve("raw-wiktextract-data-" + lang + ".jsonl.gz.part");
-        HttpClient client = HttpClient.newBuilder()
-                .connectTimeout(Duration.ofSeconds(30))
-                .build();
+        Path partPath = dumpsDir.resolve("raw-wiktextract-data-" + lang + ".jsonl.gz.part");
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(url))
                 .timeout(Duration.ofSeconds(30))
                 .build();
 
         try {
-            HttpResponse<Path> response = client.send(request, HttpResponse.BodyHandlers.ofFile(partPath));
+            HttpResponse<Path> response = httpClient.send(request, HttpResponse.BodyHandlers.ofFile(partPath));
             if (response.statusCode() != 200) {
                 log.error("Download failed — HTTP {}", response.statusCode());
                 Files.deleteIfExists(partPath);
@@ -68,7 +74,7 @@ public class KaikkiDumpDownloader implements DumpDownloader {
                 }
             }
 
-            Path dumpPath = DUMPS_DIR.resolve("raw-wiktextract-data-" + lang + "-" + generatedDate + ".jsonl.gz");
+            Path dumpPath = dumpsDir.resolve("raw-wiktextract-data-" + lang + "-" + generatedDate + ".jsonl.gz");
             if (Files.exists(dumpPath)) {
                 log.info("Dump already exists at {}. Delete it to re-download.", dumpPath);
                 Files.deleteIfExists(partPath);

--- a/src/main/java/edu/self/w2k/kindling/KindlingDownloader.java
+++ b/src/main/java/edu/self/w2k/kindling/KindlingDownloader.java
@@ -15,9 +15,12 @@ import java.time.Duration;
 import java.util.HexFormat;
 import java.util.Set;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public class KindlingDownloader {
 
     private static final String RELEASE_BASE = "https://github.com/ciscoriordan/kindling/releases/download";
@@ -25,16 +28,16 @@ public class KindlingDownloader {
 
     private final HttpFetcher fetcher;
 
-    public KindlingDownloader(HttpClient httpClient) {
-        this.fetcher = new DefaultHttpFetcher(httpClient);
+    public KindlingDownloader() {
+        this(new DefaultHttpFetcher(HttpClient.newBuilder()
+                                            .followRedirects(HttpClient.Redirect.NORMAL)
+                                            .connectTimeout(Duration.ofSeconds(30))
+                                            .build()));
     }
 
-    KindlingDownloader(HttpFetcher fetcher) {
-        this.fetcher = fetcher;
-    }
-
-    public Path download(String version, KindlingPlatform platform, Path destDir)
-            throws IOException, KindlingException {
+    public Path download(String version,
+                         KindlingPlatform platform,
+                         Path destDir) throws IOException, KindlingException {
         String assetName = platform.assetName();
         String expectedSha256 = resolveDigest(version, platform, assetName);
 
@@ -62,16 +65,15 @@ public class KindlingDownloader {
             markExecutable(finalPath);
             log.info("kindling binary ready at {}", finalPath);
             return finalPath;
-        } catch (KindlingException e) {
-            throw e;
         } catch (IOException e) {
             Files.deleteIfExists(partPath);
             throw e;
         }
     }
 
-    private String resolveDigest(String version, KindlingPlatform platform, String assetName)
-            throws IOException, KindlingException {
+    private String resolveDigest(String version,
+                                 KindlingPlatform platform,
+                                 String assetName) throws IOException, KindlingException {
         if (version.equals(KindlingRelease.DEFAULT_VERSION)
                 && KindlingRelease.DEFAULT_ASSETS.containsKey(platform)) {
             return KindlingRelease.DEFAULT_ASSETS.get(platform).sha256();

--- a/src/test/java/edu/self/w2k/command/DownloadCommandTest.java
+++ b/src/test/java/edu/self/w2k/command/DownloadCommandTest.java
@@ -20,8 +20,6 @@ class DownloadCommandTest {
 
     @Test
     void should_invoke_downloader_when_run_is_called() {
-        // Given (no setup needed)
-
         // When
         unit.run();
 

--- a/src/test/java/edu/self/w2k/command/DownloadCommandTest.java
+++ b/src/test/java/edu/self/w2k/command/DownloadCommandTest.java
@@ -1,0 +1,31 @@
+package edu.self.w2k.command;
+
+import edu.self.w2k.download.DumpDownloader;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class DownloadCommandTest {
+
+    @Mock
+    private DumpDownloader downloader;
+
+    @InjectMocks
+    private DownloadCommand unit;
+
+    @Test
+    void should_invoke_downloader_when_run_is_called() {
+        // Given (no setup needed)
+
+        // When
+        unit.run();
+
+        // Then
+        verify(downloader).download();
+    }
+}

--- a/src/test/java/edu/self/w2k/command/GenerateCommandTest.java
+++ b/src/test/java/edu/self/w2k/command/GenerateCommandTest.java
@@ -11,7 +11,6 @@ import edu.self.w2k.model.WiktionaryEntry;
 import edu.self.w2k.parse.DictionaryParser;
 import edu.self.w2k.render.DefinitionRenderer;
 import edu.self.w2k.write.DictionaryWriter;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -40,17 +39,10 @@ class GenerateCommandTest {
     @TempDir
     Path tmp;
 
-    private GenerateCommand unit;
-
-    @BeforeEach
-    void setUp() {
-        unit = new GenerateCommand(parser, renderer, writer, tmp.resolve("dump.jsonl.gz"), tmp, "el", "en", "Test Title");
-    }
-
     @Test
-    @SuppressWarnings("unchecked")
     void should_group_entries_and_write_dictionary_when_run() throws Exception {
         // Given
+        GenerateCommand unit = new GenerateCommand(parser, renderer, writer, tmp.resolve("dump.jsonl.gz"), tmp, "el", "en", "Test Title");
         WiktionaryEntry entry1 = new WiktionaryEntry("Apple", "el", List.of());
         WiktionaryEntry entry2 = new WiktionaryEntry("apple", "el", List.of());
         WiktionaryEntry entry3 = new WiktionaryEntry("banana", "el", List.of());
@@ -61,8 +53,7 @@ class GenerateCommandTest {
         unit.run();
 
         // Then
-        ArgumentCaptor<TreeMap<String, List<LexiconEntry>>> captor =
-                ArgumentCaptor.forClass((Class<TreeMap<String, List<LexiconEntry>>>) (Class<?>) TreeMap.class);
+        ArgumentCaptor<TreeMap<String, List<LexiconEntry>>> captor = ArgumentCaptor.captor();
         verify(writer).write(captor.capture(), eq("el"), eq("en"), eq("Test Title"), eq(tmp));
         TreeMap<String, List<LexiconEntry>> captured = captor.getValue();
         assertThat(captured).containsKeys("apple", "banana");
@@ -70,9 +61,9 @@ class GenerateCommandTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void should_skip_entries_when_renderer_returns_empty() throws Exception {
         // Given
+        GenerateCommand unit = new GenerateCommand(parser, renderer, writer, tmp.resolve("dump.jsonl.gz"), tmp, "el", "en", "Test Title");
         WiktionaryEntry entry1 = new WiktionaryEntry("apple", "el", List.of());
         WiktionaryEntry entry2 = new WiktionaryEntry("banana", "el", List.of());
         when(parser.parse(any(Path.class), eq("el"))).thenReturn(Stream.of(entry1, entry2));
@@ -84,16 +75,14 @@ class GenerateCommandTest {
         unit.run();
 
         // Then
-        ArgumentCaptor<TreeMap<String, List<LexiconEntry>>> captor =
-                ArgumentCaptor.forClass((Class<TreeMap<String, List<LexiconEntry>>>) (Class<?>) TreeMap.class);
+        ArgumentCaptor<TreeMap<String, List<LexiconEntry>>> captor = ArgumentCaptor.captor();
         verify(writer).write(captor.capture(), eq("el"), eq("en"), eq("Test Title"), eq(tmp));
-        TreeMap<String, List<LexiconEntry>> captured = captor.getValue();
-        assertThat(captured).containsOnlyKeys("apple");
+        assertThat(captor.getValue()).containsOnlyKeys("apple");
     }
 
     @Test
     void should_lowercase_and_strip_when_normalising_key() {
-        // Given / When
+        // When
         String result = GenerateCommand.normaliseKey("  Hello  ");
 
         // Then
@@ -102,7 +91,7 @@ class GenerateCommandTest {
 
     @Test
     void should_replace_quotes_and_escape_angle_brackets_when_normalising_key() {
-        // Given / When
+        // When
         String result = GenerateCommand.normaliseKey("\"<a>\"");
 
         // Then

--- a/src/test/java/edu/self/w2k/command/GenerateCommandTest.java
+++ b/src/test/java/edu/self/w2k/command/GenerateCommandTest.java
@@ -1,118 +1,111 @@
 package edu.self.w2k.command;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.io.BufferedWriter;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.zip.GZIPOutputStream;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.stream.Stream;
 
+import edu.self.w2k.model.LexiconEntry;
+import edu.self.w2k.model.WiktionaryEntry;
+import edu.self.w2k.parse.DictionaryParser;
+import edu.self.w2k.render.DefinitionRenderer;
+import edu.self.w2k.write.DictionaryWriter;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import edu.self.w2k.parse.JsonlDictionaryParser;
-import edu.self.w2k.render.HtmlDefinitionRenderer;
-import edu.self.w2k.write.DictionaryTitles;
-import edu.self.w2k.write.opf.OpfDictionaryWriter;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class GenerateCommandTest {
 
-    // ── helpers ───────────────────────────────────────────────────────────────
+    @Mock
+    private DictionaryParser parser;
 
-    private static Path writeGzipJsonl(Path dir, List<String> lines) throws IOException {
-        Path gzip = dir.resolve("dump.jsonl.gz");
-        try (GZIPOutputStream gz = new GZIPOutputStream(new FileOutputStream(gzip.toFile()));
-             BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(gz, StandardCharsets.UTF_8))) {
-            for (String line : lines) {
-                bw.write(line);
-                bw.newLine();
-            }
-        }
-        return gzip;
-    }
+    @Mock
+    private DefinitionRenderer renderer;
 
-    private static GenerateCommand buildCommand(Path dumpFile, Path outputDir, String lang) {
-        return new GenerateCommand(
-                new JsonlDictionaryParser(),
-                new HtmlDefinitionRenderer(),
-                new OpfDictionaryWriter(),
-                dumpFile,
-                outputDir,
-                lang,
-                lang,
-                DictionaryTitles.autoTitle(lang, lang)
-        );
-    }
+    @Mock
+    private DictionaryWriter writer;
 
-    // ── pipeline tests ────────────────────────────────────────────────────────
+    @TempDir
+    Path tmp;
 
-    @Test
-    void run_jsonlDumpToOpf(@TempDir Path tempDir) throws Exception {
-        Path dump = writeGzipJsonl(tempDir, List.of(
-                "{\"word\":\"hello\",\"lang_code\":\"en\",\"senses\":[{\"glosses\":[\"a greeting\"],\"examples\":[{\"text\":\"Hello, world!\"}]}]}",
-                "{\"word\":\"world\",\"lang_code\":\"en\",\"senses\":[{\"glosses\":[\"the earth\"],\"examples\":[]}]}"
-        ));
+    private GenerateCommand unit;
 
-        buildCommand(dump, tempDir, "en").run();
-
-        assertTrue(Files.exists(tempDir.resolve("dictionary-en-en.opf")), "OPF file must be created");
+    @BeforeEach
+    void setUp() {
+        unit = new GenerateCommand(parser, renderer, writer, tmp.resolve("dump.jsonl.gz"), tmp, "el", "en", "Test Title");
     }
 
     @Test
-    void run_langFilteringApplied(@TempDir Path tempDir) throws Exception {
-        Path dump = writeGzipJsonl(tempDir, List.of(
-                "{\"word\":\"hello\",\"lang_code\":\"en\",\"senses\":[{\"glosses\":[\"a greeting\"],\"examples\":[]}]}",
-                "{\"word\":\"Hund\",\"lang_code\":\"de\",\"senses\":[{\"glosses\":[\"dog\"],\"examples\":[]}]}",
-                "{\"word\":\"gato\",\"lang_code\":\"es\",\"senses\":[{\"glosses\":[\"cat\"],\"examples\":[]}]}"
-        ));
+    @SuppressWarnings("unchecked")
+    void should_group_entries_and_write_dictionary_when_run() throws Exception {
+        // Given
+        WiktionaryEntry entry1 = new WiktionaryEntry("Apple", "el", List.of());
+        WiktionaryEntry entry2 = new WiktionaryEntry("apple", "el", List.of());
+        WiktionaryEntry entry3 = new WiktionaryEntry("banana", "el", List.of());
+        when(parser.parse(any(Path.class), eq("el"))).thenReturn(Stream.of(entry1, entry2, entry3));
+        when(renderer.render(any())).thenReturn(Optional.of("<def>"));
 
-        buildCommand(dump, tempDir, "en").run();
+        // When
+        unit.run();
 
-        assertTrue(Files.exists(tempDir.resolve("dictionary-en-en.opf")), "OPF must be created");
+        // Then
+        ArgumentCaptor<TreeMap<String, List<LexiconEntry>>> captor =
+                ArgumentCaptor.forClass((Class<TreeMap<String, List<LexiconEntry>>>) (Class<?>) TreeMap.class);
+        verify(writer).write(captor.capture(), eq("el"), eq("en"), eq("Test Title"), eq(tmp));
+        TreeMap<String, List<LexiconEntry>> captured = captor.getValue();
+        assertThat(captured).containsKeys("apple", "banana");
+        assertThat(captured.get("apple")).hasSize(2);
     }
 
     @Test
-    void run_formOfEntriesExcluded(@TempDir Path tempDir) throws Exception {
-        Path dump = writeGzipJsonl(tempDir, List.of(
-                "{\"word\":\"ran\",\"lang_code\":\"en\",\"senses\":[{\"form_of\":[{\"word\":\"run\"}]}]}",
-                "{\"word\":\"run\",\"lang_code\":\"en\",\"senses\":[{\"glosses\":[\"to move fast\"],\"examples\":[]}]}"
-        ));
+    @SuppressWarnings("unchecked")
+    void should_skip_entries_when_renderer_returns_empty() throws Exception {
+        // Given
+        WiktionaryEntry entry1 = new WiktionaryEntry("apple", "el", List.of());
+        WiktionaryEntry entry2 = new WiktionaryEntry("banana", "el", List.of());
+        when(parser.parse(any(Path.class), eq("el"))).thenReturn(Stream.of(entry1, entry2));
+        when(renderer.render(any()))
+                .thenReturn(Optional.of("<def>"))
+                .thenReturn(Optional.empty());
 
-        buildCommand(dump, tempDir, "en").run();
+        // When
+        unit.run();
 
-        assertTrue(Files.exists(tempDir.resolve("dictionary-en-en.opf")), "OPF must be created");
-    }
-
-    // ── normaliseKey unit tests ───────────────────────────────────────────────
-
-    @Test
-    void normaliseKey_lowercasesWord() {
-        assertEquals("hello", GenerateCommand.normaliseKey("Hello"));
-    }
-
-    @Test
-    void normaliseKey_stripsWhitespace() {
-        assertEquals("hello", GenerateCommand.normaliseKey("  hello  "));
-    }
-
-    @Test
-    void normaliseKey_replacesDoubleQuote() {
-        assertEquals("it's", GenerateCommand.normaliseKey("it\"s"));
+        // Then
+        ArgumentCaptor<TreeMap<String, List<LexiconEntry>>> captor =
+                ArgumentCaptor.forClass((Class<TreeMap<String, List<LexiconEntry>>>) (Class<?>) TreeMap.class);
+        verify(writer).write(captor.capture(), eq("el"), eq("en"), eq("Test Title"), eq(tmp));
+        TreeMap<String, List<LexiconEntry>> captured = captor.getValue();
+        assertThat(captured).containsOnlyKeys("apple");
     }
 
     @Test
-    void normaliseKey_escapesAngleBrackets() {
-        assertEquals("\\<b\\>", GenerateCommand.normaliseKey("<b>"));
+    void should_lowercase_and_strip_when_normalising_key() {
+        // Given / When
+        String result = GenerateCommand.normaliseKey("  Hello  ");
+
+        // Then
+        assertThat(result).isEqualTo("hello");
     }
 
     @Test
-    void normaliseKey_emptyStringRemainsEmpty() {
-        assertEquals("", GenerateCommand.normaliseKey("   "));
+    void should_replace_quotes_and_escape_angle_brackets_when_normalising_key() {
+        // Given / When
+        String result = GenerateCommand.normaliseKey("\"<a>\"");
+
+        // Then
+        assertThat(result).isEqualTo("'\\<a\\>'");
     }
 }

--- a/src/test/java/edu/self/w2k/download/KaikkiDumpDownloaderTest.java
+++ b/src/test/java/edu/self/w2k/download/KaikkiDumpDownloaderTest.java
@@ -1,5 +1,10 @@
 package edu.self.w2k.download;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
 import java.net.http.HttpClient;
 import java.net.http.HttpHeaders;
 import java.net.http.HttpResponse;
@@ -8,16 +13,12 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class KaikkiDumpDownloaderTest {
@@ -30,6 +31,13 @@ class KaikkiDumpDownloaderTest {
 
     @TempDir
     Path tmp;
+
+    private KaikkiDumpDownloader unit;
+
+    @BeforeEach
+    void setUp() {
+        unit = new KaikkiDumpDownloader("en", httpClient, tmp);
+    }
 
     @Test
     void should_save_dump_with_date_when_download_succeeds() throws Exception {
@@ -44,8 +52,6 @@ class KaikkiDumpDownloaderTest {
             Files.write(partPath, new byte[0]);
             return mockResponse;
         }).when(httpClient).send(any(), any());
-
-        KaikkiDumpDownloader unit = new KaikkiDumpDownloader("en", httpClient, tmp);
 
         // When
         unit.download();
@@ -66,8 +72,6 @@ class KaikkiDumpDownloaderTest {
         when(mockResponse.statusCode()).thenReturn(200);
         when(mockResponse.headers()).thenReturn(headers);
         doAnswer(inv -> mockResponse).when(httpClient).send(any(), any());
-
-        KaikkiDumpDownloader unit = new KaikkiDumpDownloader("en", httpClient, tmp);
 
         // When
         unit.download();

--- a/src/test/java/edu/self/w2k/download/KaikkiDumpDownloaderTest.java
+++ b/src/test/java/edu/self/w2k/download/KaikkiDumpDownloaderTest.java
@@ -1,0 +1,101 @@
+package edu.self.w2k.download;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class KaikkiDumpDownloaderTest {
+
+    @Mock
+    private HttpClient httpClient;
+
+    @TempDir
+    Path tmp;
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void should_save_dump_with_date_when_download_succeeds() throws Exception {
+        // Given
+        Path partPath = tmp.resolve("raw-wiktextract-data-en.jsonl.gz.part");
+
+        HttpHeaders headers = HttpHeaders.of(
+                Map.of("last-modified", List.of("Fri, 01 May 2026 10:00:00 GMT")),
+                (k, v) -> true);
+        HttpResponse<Path> mockResponse = mock(HttpResponse.class);
+        when(mockResponse.statusCode()).thenReturn(200);
+        when(mockResponse.headers()).thenReturn(headers);
+        doAnswer(inv -> {
+            Files.write(partPath, new byte[0]);
+            return mockResponse;
+        }).when(httpClient).send(any(), any());
+
+        KaikkiDumpDownloader unit = new KaikkiDumpDownloader("en", httpClient, tmp);
+
+        // When
+        unit.download();
+
+        // Then
+        assertThat(tmp.resolve("raw-wiktextract-data-en-2026-05-01.jsonl.gz")).exists();
+        assertThat(partPath).doesNotExist();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void should_keep_existing_dump_when_target_already_exists() throws Exception {
+        // Given
+        Path existingDump = tmp.resolve("raw-wiktextract-data-en-2026-05-01.jsonl.gz");
+        Files.createFile(existingDump);
+
+        HttpHeaders headers = HttpHeaders.of(
+                Map.of("last-modified", List.of("Fri, 01 May 2026 10:00:00 GMT")),
+                (k, v) -> true);
+        HttpResponse<Path> mockResponse = mock(HttpResponse.class);
+        when(mockResponse.statusCode()).thenReturn(200);
+        when(mockResponse.headers()).thenReturn(headers);
+        doAnswer(inv -> mockResponse).when(httpClient).send(any(), any());
+
+        KaikkiDumpDownloader unit = new KaikkiDumpDownloader("en", httpClient, tmp);
+
+        // When
+        unit.download();
+
+        // Then
+        assertThat(existingDump).exists();
+        assertThat(tmp.resolve("raw-wiktextract-data-en.jsonl.gz.part")).doesNotExist();
+    }
+
+    @Test
+    void should_use_dictionary_path_when_lang_is_english() {
+        // Given / When
+        String url = KaikkiDumpDownloader.buildUrl("en");
+
+        // Then
+        assertThat(url).endsWith("/dictionary/raw-wiktextract-data.jsonl.gz");
+    }
+
+    @Test
+    void should_use_lang_wiktionary_path_when_lang_is_other() {
+        // Given / When
+        String url = KaikkiDumpDownloader.buildUrl("fr");
+
+        // Then
+        assertThat(url).endsWith("/frwiktionary/raw-wiktextract-data.jsonl.gz");
+    }
+}

--- a/src/test/java/edu/self/w2k/download/KaikkiDumpDownloaderTest.java
+++ b/src/test/java/edu/self/w2k/download/KaikkiDumpDownloaderTest.java
@@ -17,7 +17,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -26,19 +25,19 @@ class KaikkiDumpDownloaderTest {
     @Mock
     private HttpClient httpClient;
 
+    @Mock
+    private HttpResponse<Path> mockResponse;
+
     @TempDir
     Path tmp;
 
     @Test
-    @SuppressWarnings("unchecked")
     void should_save_dump_with_date_when_download_succeeds() throws Exception {
         // Given
         Path partPath = tmp.resolve("raw-wiktextract-data-en.jsonl.gz.part");
-
         HttpHeaders headers = HttpHeaders.of(
                 Map.of("last-modified", List.of("Fri, 01 May 2026 10:00:00 GMT")),
                 (k, v) -> true);
-        HttpResponse<Path> mockResponse = mock(HttpResponse.class);
         when(mockResponse.statusCode()).thenReturn(200);
         when(mockResponse.headers()).thenReturn(headers);
         doAnswer(inv -> {
@@ -57,16 +56,13 @@ class KaikkiDumpDownloaderTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void should_keep_existing_dump_when_target_already_exists() throws Exception {
         // Given
         Path existingDump = tmp.resolve("raw-wiktextract-data-en-2026-05-01.jsonl.gz");
         Files.createFile(existingDump);
-
         HttpHeaders headers = HttpHeaders.of(
                 Map.of("last-modified", List.of("Fri, 01 May 2026 10:00:00 GMT")),
                 (k, v) -> true);
-        HttpResponse<Path> mockResponse = mock(HttpResponse.class);
         when(mockResponse.statusCode()).thenReturn(200);
         when(mockResponse.headers()).thenReturn(headers);
         doAnswer(inv -> mockResponse).when(httpClient).send(any(), any());
@@ -83,7 +79,7 @@ class KaikkiDumpDownloaderTest {
 
     @Test
     void should_use_dictionary_path_when_lang_is_english() {
-        // Given / When
+        // When
         String url = KaikkiDumpDownloader.buildUrl("en");
 
         // Then
@@ -92,7 +88,7 @@ class KaikkiDumpDownloaderTest {
 
     @Test
     void should_use_lang_wiktionary_path_when_lang_is_other() {
-        // Given / When
+        // When
         String url = KaikkiDumpDownloader.buildUrl("fr");
 
         // Then

--- a/src/test/java/edu/self/w2k/kindling/KindlingCliResolverTest.java
+++ b/src/test/java/edu/self/w2k/kindling/KindlingCliResolverTest.java
@@ -1,218 +1,86 @@
 package edu.self.w2k.kindling;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.io.IOException;
-import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
 class KindlingCliResolverTest {
 
-    /**
-     * No-op stub fetcher used when we don't expect actual network calls.
-     */
-    private static final HttpFetcher NO_OP_FETCHER = new HttpFetcher() {
-        @Override
-        public Path getFile(URI uri, Path dest) throws IOException {
-            throw new IOException("Unexpected getFile call: " + uri);
-        }
+    @Mock
+    private KindlingDownloader downloader;
 
-        @Override
-        public String getString(URI uri) throws IOException {
-            throw new IOException("Unexpected getString call: " + uri);
-        }
-    };
+    @Mock
+    private Function<String, Optional<Path>> pathProbe;
 
-    private static KindlingDownloader noOpDownloader() {
-        return new KindlingDownloader(NO_OP_FETCHER);
-    }
+    @Mock
+    private BiFunction<String, KindlingPlatform, String> digestProvider;
 
-    // ── override binary that is executable → returned directly ────────────────
+    @TempDir
+    Path tmp;
 
     @Test
-    void resolve_overrideExecutable_returnsIt(@TempDir Path tempDir) throws Exception {
-        Path fakeExe = tempDir.resolve("kindling-cli");
-        Files.createFile(fakeExe);
-        fakeExe.toFile().setExecutable(true);
+    void should_return_override_when_override_is_executable() throws Exception {
+        // Given
+        Path executable = Files.createFile(tmp.resolve("kindling-cli"));
+        executable.toFile().setExecutable(true);
+        KindlingCliResolver unit = new KindlingCliResolver(
+                "v0.14.5", Optional.of(executable), downloader, pathProbe, digestProvider);
 
-        KindlingCliResolver resolver = new KindlingCliResolver(
-                "v0", Optional.of(fakeExe), noOpDownloader());
-        assertEquals(fakeExe, resolver.resolve());
+        // When
+        Path result = unit.resolve();
+
+        // Then
+        assertThat(result).isEqualTo(executable);
+        verify(downloader, never()).download(any(), any(), any());
     }
 
-    // ── override binary not executable → KindlingException ───────────────────
-
     @Test
-    void resolve_overrideNotExecutable_throws(@TempDir Path tempDir) throws Exception {
-        Path nonExe = tempDir.resolve("kindling-cli");
-        Files.createFile(nonExe);
-        nonExe.toFile().setExecutable(false);
+    void should_return_path_binary_when_found_on_path() throws Exception {
+        // Given
+        Path executableOnPath = Files.createFile(tmp.resolve("kindling-cli-on-path"));
+        executableOnPath.toFile().setExecutable(true);
+        when(pathProbe.apply("kindling-cli")).thenReturn(Optional.of(executableOnPath));
+        KindlingCliResolver unit = new KindlingCliResolver(
+                "v0.14.5", Optional.empty(), downloader, pathProbe, digestProvider);
 
-        KindlingCliResolver resolver = new KindlingCliResolver(
-                "v0", Optional.of(nonExe), noOpDownloader());
-        assertThrows(KindlingException.class, resolver::resolve);
+        // When
+        Path result = unit.resolve();
+
+        // Then
+        assertThat(result).isEqualTo(executableOnPath);
+        verify(downloader, never()).download(any(), any(), any());
     }
 
-    // ── PATH probe finds executable → returned ───────────────────────────────
-
     @Test
-    void resolve_pathProbeFindsExecutable_returnsIt(@TempDir Path tempDir) throws Exception {
-        Path fakeExe = tempDir.resolve("kindling-cli");
-        Files.createFile(fakeExe);
-        fakeExe.toFile().setExecutable(true);
+    void should_download_when_cache_is_empty() throws Exception {
+        // Given
+        Path downloadedBin = tmp.resolve("kindling-cli-linux");
+        when(pathProbe.apply(anyString())).thenReturn(Optional.empty());
+        when(downloader.download(any(), any(), any())).thenReturn(downloadedBin);
+        KindlingCliResolver unit = new KindlingCliResolver(
+                "v999.999.999", Optional.empty(), downloader, pathProbe, digestProvider);
 
-        KindlingCliResolver resolver = new KindlingCliResolver(
-                "v0", Optional.empty(), noOpDownloader(),
-                name -> Optional.of(fakeExe),
-                (v, p) -> null);
-        assertEquals(fakeExe, resolver.resolve());
-    }
+        // When
+        Path result = unit.resolve();
 
-    // ── cache hit, no digest (non-default version) → cached binary returned ──
-
-    @Test
-    void resolve_cacheHit_noDigest_returnsCached(@TempDir Path cacheDir) throws Exception {
-        // Simulate a cached binary already in place
-        KindlingPlatform platform = KindlingPlatform.LINUX_X64;
-        Path versionDir = cacheDir.resolve("v9.0.0");
-        Files.createDirectories(versionDir);
-        Path cachedBin = versionDir.resolve(platform.assetName());
-        Files.createFile(cachedBin);
-        cachedBin.toFile().setExecutable(true);
-
-        // Use PATH probe to return the pre-created file; digest check is skipped (null → valid).
-        KindlingCliResolver resolverViaPath = new KindlingCliResolver(
-                "v9.0.0", Optional.empty(), noOpDownloader(),
-                name -> Optional.of(cachedBin),
-                (v, p) -> null);
-        Path result = resolverViaPath.resolve();
-        assertEquals(cachedBin, result);
-    }
-
-    // ── cache hit, digest mismatch → downloader called ───────────────────────
-
-    @Test
-    void resolve_cacheHit_digestMismatch_downloaderCalled(@TempDir Path tempDir) throws Exception {
-        KindlingPlatform platform = KindlingPlatform.LINUX_X64;
-        String version = "v9.0.0";
-
-        // Create a fake cached binary with known content
-        Path cacheDir = tempDir.resolve(version);
-        Files.createDirectories(cacheDir);
-        Path cachedBin = cacheDir.resolve(platform.assetName());
-        Files.write(cachedBin, "old-content".getBytes());
-
-        // Create a "downloaded" binary that the stub downloader will return
-        Path downloadedBin = tempDir.resolve("downloaded-" + platform.assetName());
-        Files.write(downloadedBin, "new-content".getBytes());
-        downloadedBin.toFile().setExecutable(true);
-
-        // Stub fetcher that serves new-content and provides sha256 matching it
-        byte[] newContent = "new-content".getBytes();
-        String newSha256 = KindlingDownloader.sha256(downloadedBin);
-        String apiUrl = "https://api.github.com/repos/ciscoriordan/kindling/releases/tags/" + version;
-
-        HttpFetcher stubFetcher = new HttpFetcher() {
-            @Override
-            public Path getFile(URI uri, Path dest) throws IOException {
-                Files.write(dest, newContent);
-                return dest;
-            }
-
-            @Override
-            public String getString(URI uri) throws IOException {
-                if (uri.toString().equals(apiUrl)) {
-                    return "{\"assets\":[{\"name\":\"%s\",\"digest\":\"sha256:%s\"}]}"
-                            .formatted(platform.assetName(), newSha256);
-                }
-                throw new IOException("Unexpected: " + uri);
-            }
-        };
-
-        KindlingDownloader downloader = new KindlingDownloader(stubFetcher);
-
-        // digestProvider returns "expected-hash" which won't match "old-content"
-        KindlingCliResolver resolver = new KindlingCliResolver(
-                version, Optional.empty(), downloader,
-                name -> Optional.empty(),  // PATH probe misses
-                (v, p) -> "expected-hash-that-wont-match") {
-            @Override
-            public Path resolve() throws IOException, KindlingException {
-                // Override resolve to inject our tempDir as cache location
-                Path cached = cacheDir.resolve(platform.assetName());
-                if (Files.exists(cached)) {
-                    String expected = "expected-hash-that-wont-match";
-                    String actual;
-                    try {
-                        actual = KindlingDownloader.sha256(cached);
-                    } catch (IOException _) {
-                        actual = "";
-                    }
-                    if (!expected.equalsIgnoreCase(actual)) {
-                        Files.deleteIfExists(cached);
-                        return downloader.download(version, platform, cacheDir);
-                    }
-                    return cached;
-                }
-                return downloader.download(version, platform, cacheDir);
-            }
-        };
-
-        Path result = resolver.resolve();
-        assertTrue(Files.exists(result), "Downloaded binary must exist");
-        // The old cached binary content should be replaced
-        assertEquals("new-content", Files.readString(result));
-    }
-
-    // ── no cache → downloader called ─────────────────────────────────────────
-
-    @Test
-    void resolve_noCache_downloaderCalled(@TempDir Path tempDir) throws Exception {
-        KindlingPlatform platform = KindlingPlatform.LINUX_X64;
-        String version = "v9.0.0";
-
-        byte[] binContent = "fresh-binary".getBytes();
-
-        // Compute sha256 of the bytes we'll serve
-        java.security.MessageDigest md = java.security.MessageDigest.getInstance("SHA-256");
-        String actualSha256 = java.util.HexFormat.of().formatHex(md.digest(binContent));
-
-        HttpFetcher stubFetcher = new HttpFetcher() {
-            @Override
-            public Path getFile(URI uri, Path dest) throws IOException {
-                Files.write(dest, binContent);
-                return dest;
-            }
-
-            @Override
-            public String getString(URI uri) throws IOException {
-                return "{\"assets\":[{\"name\":\"%s\",\"digest\":\"sha256:%s\"}]}"
-                        .formatted(platform.assetName(), actualSha256);
-            }
-        };
-
-        KindlingDownloader downloader = new KindlingDownloader(stubFetcher);
-
-        Path downloadCacheDir = tempDir.resolve(version);
-        // Subclass to inject tempDir as cache
-        KindlingCliResolver resolver = new KindlingCliResolver(
-                version, Optional.empty(), downloader,
-                name -> Optional.empty(),
-                (v, p) -> null) {
-            @Override
-            public Path resolve() throws IOException, KindlingException {
-                return downloader.download(version, platform, downloadCacheDir);
-            }
-        };
-
-        Path result = resolver.resolve();
-        assertTrue(Files.exists(result), "Downloaded binary must exist");
+        // Then
+        assertThat(result).isEqualTo(downloadedBin);
+        verify(downloader).download(any(), any(), any());
     }
 }

--- a/src/test/java/edu/self/w2k/kindling/KindlingDictionaryConverterTest.java
+++ b/src/test/java/edu/self/w2k/kindling/KindlingDictionaryConverterTest.java
@@ -42,7 +42,6 @@ class KindlingDictionaryConverterTest {
     Path outputDir;
 
     @Test
-    @SuppressWarnings("unchecked")
     void should_run_kindling_cli_and_return_mobi_path_when_write() throws Exception {
         // Given
         Path opfPath = outputDir.resolve("dictionary-en-fr.opf");
@@ -57,10 +56,9 @@ class KindlingDictionaryConverterTest {
         // Then
         assertThat(result).isEqualTo(outputDir.resolve("dictionary-en-fr.mobi"));
 
-        ArgumentCaptor<List<String>> commandCaptor = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<List<String>> commandCaptor = ArgumentCaptor.captor();
         verify(runner).run(commandCaptor.capture());
-        List<String> command = commandCaptor.getValue();
-        assertThat(command)
+        assertThat(commandCaptor.getValue())
                 .contains("build")
                 .contains("-o")
                 .anyMatch(s -> s.endsWith("dictionary-en-fr.opf"))

--- a/src/test/java/edu/self/w2k/kindling/KindlingDictionaryConverterTest.java
+++ b/src/test/java/edu/self/w2k/kindling/KindlingDictionaryConverterTest.java
@@ -1,132 +1,84 @@
 package edu.self.w2k.kindling;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.io.IOException;
-import java.net.URI;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.TreeMap;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-
-import edu.self.w2k.model.LexiconEntry;
+import edu.self.w2k.kindling.KindlingDictionaryConverter.ProcessRunner;
 import edu.self.w2k.write.opf.OpfDictionaryWriter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
 class KindlingDictionaryConverterTest {
 
-    private static final HttpFetcher NO_OP_FETCHER = new HttpFetcher() {
-        @Override
-        public Path getFile(URI uri, Path dest) throws IOException {
-            throw new IOException("Unexpected getFile: " + uri);
-        }
+    @Mock
+    private OpfDictionaryWriter opfWriter;
 
-        @Override
-        public String getString(URI uri) throws IOException {
-            throw new IOException("Unexpected getString: " + uri);
-        }
-    };
+    @Mock
+    private KindlingCliResolver resolver;
 
-    /**
-     * Resolver subclass that always returns a specified fake binary path.
-     */
-    private static KindlingCliResolver fixedBinResolver(Path fakeBin) {
-        return new KindlingCliResolver("v0", Optional.empty(), new KindlingDownloader(NO_OP_FETCHER),
-                name -> Optional.empty(),
-                (v, p) -> null) {
-            @Override
-            public Path resolve() {
-                return fakeBin;
-            }
-        };
-    }
+    @Mock
+    private ProcessRunner runner;
 
-    private static TreeMap<String, List<LexiconEntry>> buildDefs(String... words) {
-        TreeMap<String, List<LexiconEntry>> defs = new TreeMap<>();
-        for (String word : words) {
-            defs.put(word, List.of(new LexiconEntry(word, "<ol><li>def of " + word + "</li></ol>")));
-        }
-        return defs;
-    }
+    @InjectMocks
+    private KindlingDictionaryConverter unit;
 
-    // ── happy path ────────────────────────────────────────────────────────────
+    @TempDir
+    Path outputDir;
 
     @Test
-    void write_capturesCorrectCommand(@TempDir Path tempDir) throws Exception {
-        Path fakeBin = tempDir.resolve("kindling-cli");
-        Files.createFile(fakeBin);
-        fakeBin.toFile().setExecutable(true);
+    @SuppressWarnings("unchecked")
+    void should_run_kindling_cli_and_return_mobi_path_when_write() throws Exception {
+        // Given
+        Path opfPath = outputDir.resolve("dictionary-en-fr.opf");
+        Path binPath = outputDir.resolve("kindling-cli");
+        when(opfWriter.write(any(), eq("en"), eq("fr"), eq("Title"), eq(outputDir))).thenReturn(opfPath);
+        when(resolver.resolve()).thenReturn(binPath);
+        when(runner.run(anyList())).thenReturn(0);
 
-        List<List<String>> captured = new ArrayList<>();
-        KindlingDictionaryConverter.ProcessRunner runner = cmd -> {
-            captured.add(new ArrayList<>(cmd));
-            return 0;
-        };
+        // When
+        Path result = unit.write(new TreeMap<>(), "en", "fr", "Title", outputDir);
 
-        KindlingDictionaryConverter converter = new KindlingDictionaryConverter(
-                new OpfDictionaryWriter(), fixedBinResolver(fakeBin), runner);
+        // Then
+        assertThat(result).isEqualTo(outputDir.resolve("dictionary-en-fr.mobi"));
 
-        Path result = converter.write(buildDefs("alpha", "beta"), "el", "en", "Title", tempDir);
-        assertTrue(result.toString().endsWith("dictionary-el-en.mobi"), "returned path must be the mobi file");
-
-        assertEquals(1, captured.size(), "exactly one command must be run");
-        List<String> cmd = captured.getFirst();
-        assertEquals(fakeBin.toString(), cmd.get(0), "first arg is the kindling binary");
-        assertEquals("build", cmd.get(1), "second arg is 'build'");
-        assertTrue(cmd.get(2).endsWith("dictionary-el-en.opf"), "third arg is the OPF path");
-        assertEquals("-o", cmd.get(3), "fourth arg is -o");
-        assertTrue(cmd.get(4).endsWith("dictionary-el-en.mobi"), "fifth arg is the MOBI output path");
+        ArgumentCaptor<List<String>> commandCaptor = ArgumentCaptor.forClass(List.class);
+        verify(runner).run(commandCaptor.capture());
+        List<String> command = commandCaptor.getValue();
+        assertThat(command)
+                .contains("build")
+                .contains("-o")
+                .anyMatch(s -> s.endsWith("dictionary-en-fr.opf"))
+                .anyMatch(s -> s.endsWith("dictionary-en-fr.mobi"));
     }
 
     @Test
-    void write_returnsPathEndingInMobi(@TempDir Path tempDir) throws Exception {
-        Path fakeBin = tempDir.resolve("kindling-cli");
-        Files.createFile(fakeBin);
-        fakeBin.toFile().setExecutable(true);
+    void should_throw_io_exception_when_runner_returns_non_zero_exit_code() throws Exception {
+        // Given
+        Path opfPath = outputDir.resolve("dictionary-en-fr.opf");
+        Path binPath = outputDir.resolve("kindling-cli");
+        when(opfWriter.write(any(), eq("en"), eq("fr"), eq("Title"), eq(outputDir))).thenReturn(opfPath);
+        when(resolver.resolve()).thenReturn(binPath);
+        when(runner.run(anyList())).thenReturn(1);
 
-        KindlingDictionaryConverter converter = new KindlingDictionaryConverter(
-                new OpfDictionaryWriter(), fixedBinResolver(fakeBin), cmd -> 0);
-
-        Path result = converter.write(buildDefs("alpha"), "el", "en", "Title", tempDir);
-        assertTrue(result.toString().endsWith("dictionary-el-en.mobi"), "result must end in .mobi");
-    }
-
-    @Test
-    void write_opfAndHtmlFilesExist(@TempDir Path tempDir) throws Exception {
-        Path fakeBin = tempDir.resolve("kindling-cli");
-        Files.createFile(fakeBin);
-
-        KindlingDictionaryConverter converter = new KindlingDictionaryConverter(
-                new OpfDictionaryWriter(), fixedBinResolver(fakeBin), cmd -> 0);
-
-        converter.write(buildDefs("alpha", "beta", "gamma"), "el", "en", "Title", tempDir);
-
-        assertTrue(Files.exists(tempDir.resolve("dictionary-el-en.opf")), "OPF file must exist");
-
-        List<Path> htmlFiles = new ArrayList<>();
-        try (var stream = Files.newDirectoryStream(tempDir, "*.html")) {
-            for (Path p : stream) htmlFiles.add(p);
-        }
-        assertTrue(htmlFiles.size() >= 1, "at least one HTML file must exist");
-    }
-
-    // ── non-zero exit → IOException ───────────────────────────────────────────
-
-    @Test
-    void write_nonZeroExit_throwsIOException(@TempDir Path tempDir) throws Exception {
-        Path fakeBin = tempDir.resolve("kindling-cli");
-        Files.createFile(fakeBin);
-
-        KindlingDictionaryConverter converter = new KindlingDictionaryConverter(
-                new OpfDictionaryWriter(), fixedBinResolver(fakeBin), cmd -> 1);
-
-        assertThrows(IOException.class,
-                () -> converter.write(buildDefs("alpha"), "el", "en", "Title", tempDir));
+        // When / Then
+        assertThatThrownBy(() -> unit.write(new TreeMap<>(), "en", "fr", "Title", outputDir))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("exit");
     }
 }

--- a/src/test/java/edu/self/w2k/kindling/KindlingDownloaderTest.java
+++ b/src/test/java/edu/self/w2k/kindling/KindlingDownloaderTest.java
@@ -7,7 +7,6 @@ import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.util.HexFormat;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -28,16 +27,10 @@ class KindlingDownloaderTest {
     @TempDir
     Path destDir;
 
-    private KindlingDownloader unit;
-
-    @BeforeEach
-    void setUp() {
-        unit = new KindlingDownloader(fetcher);
-    }
-
     @Test
     void should_download_and_return_final_path_when_sha256_matches() throws Exception {
         // Given
+        KindlingDownloader unit = new KindlingDownloader(fetcher);
         byte[] payload = "test-payload-content".getBytes(StandardCharsets.UTF_8);
         String sha256 = HexFormat.of().formatHex(
                 MessageDigest.getInstance("SHA-256").digest(payload));
@@ -57,14 +50,16 @@ class KindlingDownloaderTest {
         Path result = unit.download(version, platform, destDir);
 
         // Then
-        assertThat(result).isEqualTo(destDir.resolve(assetName));
-        assertThat(result).exists();
+        assertThat(result)
+                .isEqualTo(destDir.resolve(assetName))
+                .exists();
         assertThat(destDir.resolve("." + assetName + ".part")).doesNotExist();
     }
 
     @Test
     void should_throw_when_sha256_mismatch() throws Exception {
         // Given
+        KindlingDownloader unit = new KindlingDownloader(fetcher);
         byte[] correctPayload = "correct-content".getBytes(StandardCharsets.UTF_8);
         String correctSha256 = HexFormat.of().formatHex(
                 MessageDigest.getInstance("SHA-256").digest(correctPayload));

--- a/src/test/java/edu/self/w2k/kindling/KindlingDownloaderTest.java
+++ b/src/test/java/edu/self/w2k/kindling/KindlingDownloaderTest.java
@@ -1,159 +1,89 @@
 package edu.self.w2k.kindling;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
 class KindlingDownloaderTest {
 
-    /**
-     * Stub HttpFetcher that serves fixed byte[] payloads keyed by URI string.
-     * Writing bytes to dest simulates a real download.
-     */
-    private static final class StubFetcher implements HttpFetcher {
-        private final Map<String, byte[]> filePayloads = new ConcurrentHashMap<>();
-        private final Map<String, String> stringResponses = new ConcurrentHashMap<>();
+    @Mock
+    private HttpFetcher fetcher;
 
-        StubFetcher file(String uri, byte[] payload) {
-            filePayloads.put(uri, payload);
-            return this;
-        }
+    @TempDir
+    Path destDir;
 
-        StubFetcher json(String uri, String json) {
-            stringResponses.put(uri, json);
-            return this;
-        }
+    private KindlingDownloader unit;
 
-        @Override
-        public Path getFile(URI uri, Path dest) throws IOException {
-            byte[] payload = filePayloads.get(uri.toString());
-            if (payload == null) throw new IOException("No stub for " + uri);
+    @BeforeEach
+    void setUp() {
+        unit = new KindlingDownloader(fetcher);
+    }
+
+    @Test
+    void should_download_and_return_final_path_when_sha256_matches() throws Exception {
+        // Given
+        byte[] payload = "test-payload-content".getBytes(StandardCharsets.UTF_8);
+        String sha256 = HexFormat.of().formatHex(
+                MessageDigest.getInstance("SHA-256").digest(payload));
+        String version = "v1.0.0-test";
+        KindlingPlatform platform = KindlingPlatform.LINUX_X64;
+        String assetName = platform.assetName();
+        String json = "{\"name\":\"" + assetName + "\",\"digest\":\"sha256:" + sha256 + "\"}";
+
+        when(fetcher.getString(any(URI.class))).thenReturn(json);
+        when(fetcher.getFile(any(URI.class), any(Path.class))).thenAnswer(inv -> {
+            Path dest = inv.getArgument(1, Path.class);
             Files.write(dest, payload);
             return dest;
-        }
+        });
 
-        @Override
-        public String getString(URI uri) throws IOException {
-            String response = stringResponses.get(uri.toString());
-            if (response == null) throw new IOException("No stub for " + uri);
-            return response;
-        }
+        // When
+        Path result = unit.download(version, platform, destDir);
+
+        // Then
+        assertThat(result).isEqualTo(destDir.resolve(assetName));
+        assertThat(result).exists();
+        assertThat(destDir.resolve("." + assetName + ".part")).doesNotExist();
     }
-
-    private static String sha256(byte[] bytes) {
-        try {
-            MessageDigest md = MessageDigest.getInstance("SHA-256");
-            return HexFormat.of().formatHex(md.digest(bytes));
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    // ── happy path: non-default version, digest fetched from API JSON ─────────
 
     @Test
-    void download_happyPath(@TempDir Path tempDir) throws Exception {
-        String version = "v9.99.0";
+    void should_throw_when_sha256_mismatch() throws Exception {
+        // Given
+        byte[] correctPayload = "correct-content".getBytes(StandardCharsets.UTF_8);
+        String correctSha256 = HexFormat.of().formatHex(
+                MessageDigest.getInstance("SHA-256").digest(correctPayload));
+        String version = "v1.0.0-test";
         KindlingPlatform platform = KindlingPlatform.LINUX_X64;
         String assetName = platform.assetName();
+        String json = "{\"name\":\"" + assetName + "\",\"digest\":\"sha256:" + correctSha256 + "\"}";
 
-        byte[] fakeBytes = "fake-binary-content".getBytes();
-        String expectedSha256 = sha256(fakeBytes);
+        when(fetcher.getString(any(URI.class))).thenReturn(json);
+        when(fetcher.getFile(any(URI.class), any(Path.class))).thenAnswer(inv -> {
+            Path dest = inv.getArgument(1, Path.class);
+            Files.write(dest, "wrong-content".getBytes(StandardCharsets.UTF_8));
+            return dest;
+        });
 
-        String apiUrl = "https://api.github.com/repos/ciscoriordan/kindling/releases/tags/" + version;
-        String downloadUrl = "https://github.com/ciscoriordan/kindling/releases/download/" + version + "/" + assetName;
-
-        String fakeApiJson = """
-                {"assets":[{"name":"%s","digest":"sha256:%s"}]}
-                """.formatted(assetName, expectedSha256);
-
-        StubFetcher stub = new StubFetcher()
-                .json(apiUrl, fakeApiJson)
-                .file(downloadUrl, fakeBytes);
-
-        KindlingDownloader downloader = new KindlingDownloader(stub);
-        Path result = downloader.download(version, platform, tempDir);
-
-        assertEquals(tempDir.resolve(assetName), result);
-        assertTrue(Files.exists(result), "Binary file must exist after download");
-        assertFalse(Files.exists(tempDir.resolve("." + assetName + ".part")),
-                "Part file must be removed after successful download");
-    }
-
-    // ── tampered file: sha256 mismatch → KindlingException + part file removed
-
-    @Test
-    void download_sha256Mismatch_throwsAndCleansUp(@TempDir Path tempDir) throws IOException, KindlingException {
-        String version = "v9.99.0";
-        KindlingPlatform platform = KindlingPlatform.LINUX_X64;
-        String assetName = platform.assetName();
-
-        byte[] fakeBytes = "fake-binary-content".getBytes();
-        String expectedSha256 = sha256("different-content".getBytes());
-
-        String apiUrl = "https://api.github.com/repos/ciscoriordan/kindling/releases/tags/" + version;
-        String downloadUrl = "https://github.com/ciscoriordan/kindling/releases/download/" + version + "/" + assetName;
-
-        String fakeApiJson = """
-                {"assets":[{"name":"%s","digest":"sha256:%s"}]}
-                """.formatted(assetName, expectedSha256);
-
-        StubFetcher stub = new StubFetcher()
-                .json(apiUrl, fakeApiJson)
-                .file(downloadUrl, fakeBytes);
-
-        KindlingDownloader downloader = new KindlingDownloader(stub);
-
-        KindlingException ex = assertThrows(KindlingException.class,
-                () -> downloader.download(version, platform, tempDir));
-        assertTrue(ex.getMessage().contains("SHA-256 mismatch"), "exception must mention SHA-256 mismatch");
-        // The downloaded (part) file must be removed on mismatch
-        assertFalse(Files.exists(tempDir.resolve("." + assetName + ".part")),
-                "Part file must be deleted on sha256 mismatch");
-        assertFalse(Files.exists(tempDir.resolve(assetName)),
-                "Final binary must not exist on sha256 mismatch");
-    }
-
-    // ── non-default version uses API path (same as happy path, verifying the branch) ─
-
-    @Test
-    void download_nonDefaultVersion_usesApiForDigest(@TempDir Path tempDir) throws Exception {
-        String version = "v1.2.3-custom";
-        KindlingPlatform platform = KindlingPlatform.MAC_APPLE_SILICON;
-        String assetName = platform.assetName();
-
-        byte[] fakeBytes = "mac-binary".getBytes();
-        String expectedSha256 = sha256(fakeBytes);
-
-        String apiUrl = "https://api.github.com/repos/ciscoriordan/kindling/releases/tags/" + version;
-        String downloadUrl = "https://github.com/ciscoriordan/kindling/releases/download/" + version + "/" + assetName;
-
-        String fakeApiJson = """
-                {"assets":[{"name":"%s","digest":"sha256:%s"}]}
-                """.formatted(assetName, expectedSha256);
-
-        StubFetcher stub = new StubFetcher()
-                .json(apiUrl, fakeApiJson)
-                .file(downloadUrl, fakeBytes);
-
-        KindlingDownloader downloader = new KindlingDownloader(stub);
-        Path result = downloader.download(version, platform, tempDir);
-
-        assertTrue(Files.exists(result), "Binary must exist");
-        assertEquals(tempDir.resolve(assetName), result);
+        // When / Then
+        assertThatThrownBy(() -> unit.download(version, platform, destDir))
+                .isInstanceOf(KindlingException.class)
+                .hasMessageContaining("SHA-256 mismatch");
+        assertThat(destDir.resolve("." + assetName + ".part")).doesNotExist();
     }
 }

--- a/src/test/java/edu/self/w2k/kindling/KindlingPlatformTest.java
+++ b/src/test/java/edu/self/w2k/kindling/KindlingPlatformTest.java
@@ -1,47 +1,29 @@
 package edu.self.w2k.kindling;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ExtendWith(MockitoExtension.class)
 class KindlingPlatformTest {
 
     @Test
-    void linux_amd64() throws KindlingException {
-        assertEquals(KindlingPlatform.LINUX_X64, KindlingPlatform.detect("Linux", "amd64"));
+    void should_return_linux_x64_when_os_is_linux_amd64() throws KindlingException {
+        // Given / When
+        KindlingPlatform result = KindlingPlatform.detect("Linux", "amd64");
+
+        // Then
+        assertThat(result).isEqualTo(KindlingPlatform.LINUX_X64);
+        assertThat(result.assetName()).isEqualTo("kindling-cli-linux");
     }
 
     @Test
-    void linux_x86_64() throws KindlingException {
-        assertEquals(KindlingPlatform.LINUX_X64, KindlingPlatform.detect("Linux", "x86_64"));
-    }
-
-    @Test
-    void linux_aarch64_throwsWithArm64Message() {
-        KindlingException ex = assertThrows(KindlingException.class,
-                () -> KindlingPlatform.detect("Linux", "aarch64"));
-        assertTrue(ex.getMessage().contains("ARM64"), "message must mention ARM64");
-    }
-
-    @Test
-    void macos_aarch64() throws KindlingException {
-        assertEquals(KindlingPlatform.MAC_APPLE_SILICON, KindlingPlatform.detect("Mac OS X", "aarch64"));
-    }
-
-    @Test
-    void macos_x86_64() throws KindlingException {
-        assertEquals(KindlingPlatform.MAC_INTEL, KindlingPlatform.detect("Mac OS X", "x86_64"));
-    }
-
-    @Test
-    void windows_amd64() throws KindlingException {
-        assertEquals(KindlingPlatform.WINDOWS_X64, KindlingPlatform.detect("Windows 10", "amd64"));
-    }
-
-    @Test
-    void unsupportedPlatform_throws() {
-        assertThrows(KindlingException.class, () -> KindlingPlatform.detect("SunOS", "sparc"));
+    void should_throw_when_platform_is_unsupported() {
+        // Given / When / Then
+        assertThatThrownBy(() -> KindlingPlatform.detect("SunOS", "sparc"))
+                .isInstanceOf(KindlingException.class);
     }
 }

--- a/src/test/java/edu/self/w2k/kindling/KindlingPlatformTest.java
+++ b/src/test/java/edu/self/w2k/kindling/KindlingPlatformTest.java
@@ -12,7 +12,7 @@ class KindlingPlatformTest {
 
     @Test
     void should_return_linux_x64_when_os_is_linux_amd64() throws KindlingException {
-        // Given / When
+        // When
         KindlingPlatform result = KindlingPlatform.detect("Linux", "amd64");
 
         // Then
@@ -22,7 +22,7 @@ class KindlingPlatformTest {
 
     @Test
     void should_throw_when_platform_is_unsupported() {
-        // Given / When / Then
+        // When / Then
         assertThatThrownBy(() -> KindlingPlatform.detect("SunOS", "sparc"))
                 .isInstanceOf(KindlingException.class);
     }

--- a/src/test/java/edu/self/w2k/kindling/XdgCachePathsTest.java
+++ b/src/test/java/edu/self/w2k/kindling/XdgCachePathsTest.java
@@ -1,59 +1,54 @@
 package edu.self.w2k.kindling;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import java.nio.file.Path;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
 class XdgCachePathsTest {
 
     @Test
-    void linux_withXdgCacheHome() {
-        Map<String, String> env = Map.of("XDG_CACHE_HOME", "/tmp/x");
+    void should_use_xdg_cache_home_when_set_on_unix() {
+        // Given
+        Map<String, String> env = Map.of("XDG_CACHE_HOME", "/c");
+
+        // When
         Path result = XdgCachePaths.kindlingCacheDir(env, "Linux");
-        assertEquals(Path.of("/tmp/x/wiktionary-to-kindle/kindling"), result);
+
+        // Then
+        assertThat(result).isEqualTo(Path.of("/c/wiktionary-to-kindle/kindling"));
     }
 
     @Test
-    void linux_withHomeNoXdg() {
-        Map<String, String> env = Map.of("HOME", "/home/u");
+    void should_fallback_to_home_when_xdg_is_unset_on_unix() {
+        // Given
+        Map<String, String> env = Map.of("HOME", "/h");
+
+        // When
         Path result = XdgCachePaths.kindlingCacheDir(env, "Linux");
-        assertEquals(Path.of("/home/u/.cache/wiktionary-to-kindle/kindling"), result);
+
+        // Then
+        assertThat(result).isEqualTo(Path.of("/h/.cache/wiktionary-to-kindle/kindling"));
     }
 
     @Test
-    void macos_withXdgCacheHome() {
-        Map<String, String> env = Map.of("XDG_CACHE_HOME", "/tmp/x");
-        Path result = XdgCachePaths.kindlingCacheDir(env, "Mac OS X");
-        assertEquals(Path.of("/tmp/x/wiktionary-to-kindle/kindling"), result);
-    }
+    void should_use_localappdata_when_set_on_windows() {
+        // Given
+        Map<String, String> env = Map.of("LOCALAPPDATA", "C:\\local");
 
-    @Test
-    void macos_withHomeNoXdg() {
-        Map<String, String> env = Map.of("HOME", "/home/u");
-        Path result = XdgCachePaths.kindlingCacheDir(env, "Mac OS X");
-        assertEquals(Path.of("/home/u/.cache/wiktionary-to-kindle/kindling"), result);
-    }
-
-    @Test
-    void windows_withLocalAppData() {
-        Map<String, String> env = Map.of("LOCALAPPDATA", "C:\\Users\\u\\AppData\\Local");
+        // When
         Path result = XdgCachePaths.kindlingCacheDir(env, "Windows 10");
-        // Use Path.of with separate segments to get correct OS-independent separators
-        Path expected = Path.of("C:\\Users\\u\\AppData\\Local")
-                .resolve("wiktionary-to-kindle").resolve("Cache").resolve("kindling");
-        assertEquals(expected, result);
-    }
 
-    @Test
-    void windows_withUserProfileNoLocalAppData() {
-        Map<String, String> env = Map.of("USERPROFILE", "C:\\Users\\u");
-        Path result = XdgCachePaths.kindlingCacheDir(env, "Windows 10");
-        Path expected = Path.of("C:\\Users\\u")
-                .resolve("AppData").resolve("Local")
-                .resolve("wiktionary-to-kindle").resolve("Cache").resolve("kindling");
-        assertEquals(expected, result);
+        // Then
+        assertThat(result.toString())
+                .contains("wiktionary-to-kindle")
+                .contains("Cache")
+                .contains("kindling");
+        assertThat(result.startsWith(Path.of("C:\\local"))).isTrue();
     }
 }

--- a/src/test/java/edu/self/w2k/kindling/XdgCachePathsTest.java
+++ b/src/test/java/edu/self/w2k/kindling/XdgCachePathsTest.java
@@ -46,9 +46,9 @@ class XdgCachePathsTest {
 
         // Then
         assertThat(result.toString())
+                .startsWith("C:\\local")
                 .contains("wiktionary-to-kindle")
                 .contains("Cache")
                 .contains("kindling");
-        assertThat(result.startsWith(Path.of("C:\\local"))).isTrue();
     }
 }

--- a/src/test/java/edu/self/w2k/parse/JsonlDictionaryParserTest.java
+++ b/src/test/java/edu/self/w2k/parse/JsonlDictionaryParserTest.java
@@ -1,78 +1,77 @@
 package edu.self.w2k.parse;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.io.BufferedWriter;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.GZIPOutputStream;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-
 import edu.self.w2k.model.WiktionaryEntry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
 class JsonlDictionaryParserTest {
 
-    private static Path writeGzipJsonl(Path dir, String filename, List<String> lines) throws IOException {
-        Path gzip = dir.resolve(filename);
-        try (GZIPOutputStream gz = new GZIPOutputStream(new FileOutputStream(gzip.toFile()));
-             BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(gz, StandardCharsets.UTF_8))) {
-            for (String line : lines) {
-                writer.write(line);
-                writer.newLine();
-            }
+    private final JsonlDictionaryParser unit = new JsonlDictionaryParser();
+
+    @TempDir
+    Path tmp;
+
+    @Test
+    void should_return_only_entries_matching_lang_when_parsing() throws Exception {
+        // Given
+        String jsonl = "{\"word\":\"γεια\",\"lang_code\":\"el\",\"senses\":[]}\n"
+                + "{\"word\":\"hello\",\"lang_code\":\"en\",\"senses\":[]}\n";
+        Path dump = writeDump(jsonl);
+
+        // When
+        List<WiktionaryEntry> result;
+        try (Stream<WiktionaryEntry> stream = unit.parse(dump, "el")) {
+            result = stream.toList();
         }
-        return gzip;
+
+        // Then
+        assertThat(result)
+                .extracting(WiktionaryEntry::word)
+                .containsExactly("γεια");
     }
 
     @Test
-    void parse_filtersCorrectLanguage(@TempDir Path tempDir) throws IOException {
-        List<String> jsonlLines = List.of(
-                "{\"word\":\"gatos\",\"lang_code\":\"es\",\"senses\":[{\"glosses\":[\"cats\"],\"examples\":[]}]}",
-                "{\"word\":\"\u03c3\u03ba\u03cd\u03bb\u03bf\u03c2\",\"lang_code\":\"el\",\"senses\":[{\"glosses\":[\"dog\"],\"examples\":[]}]}",
-                "{\"word\":\"Hund\",\"lang_code\":\"de\",\"senses\":[{\"glosses\":[\"dog\"],\"examples\":[]}]}"
-        );
-        Path dumpFile = writeGzipJsonl(tempDir, "test.jsonl.gz", jsonlLines);
+    void should_skip_entries_with_blank_word_when_parsing() throws Exception {
+        // Given
+        String jsonl = "{\"word\":\"\",\"lang_code\":\"el\",\"senses\":[]}\n"
+                + "{\"word\":\"καλή\",\"lang_code\":\"el\",\"senses\":[]}\n";
+        Path dump = writeDump(jsonl);
 
-        List<WiktionaryEntry> result = new JsonlDictionaryParser().parse(dumpFile, "el").collect(Collectors.toList());
+        // When
+        List<WiktionaryEntry> result;
+        try (Stream<WiktionaryEntry> stream = unit.parse(dump, "el")) {
+            result = stream.toList();
+        }
 
-        assertEquals(1, result.size(), "only the Greek entry should be returned");
-        assertEquals("\u03c3\u03ba\u03cd\u03bb\u03bf\u03c2", result.get(0).word());
-        assertEquals("el", result.get(0).langCode());
+        // Then
+        assertThat(result)
+                .extracting(WiktionaryEntry::word)
+                .containsExactly("καλή");
     }
 
-    @Test
-    void parse_skipsNullWord(@TempDir Path tempDir) throws IOException {
-        List<String> jsonlLines = List.of(
-                "{\"lang_code\":\"el\",\"senses\":[{\"glosses\":[\"something\"],\"examples\":[]}]}",
-                "{\"word\":\"\u03c4\u03c1\u03ad\u03c7\u03c9\",\"lang_code\":\"el\",\"senses\":[{\"glosses\":[\"to run\"],\"examples\":[]}]}"
-        );
-        Path dumpFile = writeGzipJsonl(tempDir, "test.jsonl.gz", jsonlLines);
-
-        List<WiktionaryEntry> result = new JsonlDictionaryParser().parse(dumpFile, "el").collect(Collectors.toList());
-
-        assertEquals(1, result.size(), "entry with null word should be skipped");
-        assertEquals("\u03c4\u03c1\u03ad\u03c7\u03c9", result.get(0).word());
-    }
-
-    @Test
-    void parse_skipsOtherLanguages(@TempDir Path tempDir) throws IOException {
-        List<String> jsonlLines = List.of(
-                "{\"word\":\"cat\",\"lang_code\":\"en\",\"senses\":[{\"glosses\":[\"feline\"],\"examples\":[]}]}",
-                "{\"word\":\"chat\",\"lang_code\":\"fr\",\"senses\":[{\"glosses\":[\"cat\"],\"examples\":[]}]}",
-                "{\"word\":\"gato\",\"lang_code\":\"es\",\"senses\":[{\"glosses\":[\"cat\"],\"examples\":[]}]}"
-        );
-        Path dumpFile = writeGzipJsonl(tempDir, "test.jsonl.gz", jsonlLines);
-
-        List<WiktionaryEntry> result = new JsonlDictionaryParser().parse(dumpFile, "fr").collect(Collectors.toList());
-
-        assertEquals(1, result.size(), "only the French entry should be returned");
-        assertEquals("chat", result.get(0).word());
+    private Path writeDump(String jsonl) throws Exception {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try (GZIPOutputStream gzip = new GZIPOutputStream(bos);
+             Writer writer = new OutputStreamWriter(gzip, StandardCharsets.UTF_8)) {
+            writer.write(jsonl);
+        }
+        Path dump = tmp.resolve("dump.jsonl.gz");
+        Files.write(dump, bos.toByteArray());
+        return dump;
     }
 }

--- a/src/test/java/edu/self/w2k/parse/JsonlDictionaryParserTest.java
+++ b/src/test/java/edu/self/w2k/parse/JsonlDictionaryParserTest.java
@@ -1,5 +1,7 @@
 package edu.self.w2k.parse;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
@@ -10,13 +12,12 @@ import java.util.List;
 import java.util.stream.Stream;
 import java.util.zip.GZIPOutputStream;
 
-import edu.self.w2k.model.WiktionaryEntry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import edu.self.w2k.model.WiktionaryEntry;
 
 @ExtendWith(MockitoExtension.class)
 class JsonlDictionaryParserTest {
@@ -29,8 +30,10 @@ class JsonlDictionaryParserTest {
     @Test
     void should_return_only_entries_matching_lang_when_parsing() throws Exception {
         // Given
-        String jsonl = "{\"word\":\"γεια\",\"lang_code\":\"el\",\"senses\":[]}\n"
-                + "{\"word\":\"hello\",\"lang_code\":\"en\",\"senses\":[]}\n";
+        String jsonl = """
+                {"word":"γεια","lang_code":"el","senses":[]}
+                {"word":"hello","lang_code":"en","senses":[]}
+                """;
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         try (GZIPOutputStream gzip = new GZIPOutputStream(bos);
              Writer writer = new OutputStreamWriter(gzip, StandardCharsets.UTF_8)) {
@@ -54,8 +57,10 @@ class JsonlDictionaryParserTest {
     @Test
     void should_skip_entries_with_blank_word_when_parsing() throws Exception {
         // Given
-        String jsonl = "{\"word\":\"\",\"lang_code\":\"el\",\"senses\":[]}\n"
-                + "{\"word\":\"καλή\",\"lang_code\":\"el\",\"senses\":[]}\n";
+        String jsonl = """
+                {"word":"","lang_code":"el","senses":[]}
+                {"word":"καλή","lang_code":"el","senses":[]}
+                """;
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         try (GZIPOutputStream gzip = new GZIPOutputStream(bos);
              Writer writer = new OutputStreamWriter(gzip, StandardCharsets.UTF_8)) {

--- a/src/test/java/edu/self/w2k/parse/JsonlDictionaryParserTest.java
+++ b/src/test/java/edu/self/w2k/parse/JsonlDictionaryParserTest.java
@@ -31,7 +31,13 @@ class JsonlDictionaryParserTest {
         // Given
         String jsonl = "{\"word\":\"γεια\",\"lang_code\":\"el\",\"senses\":[]}\n"
                 + "{\"word\":\"hello\",\"lang_code\":\"en\",\"senses\":[]}\n";
-        Path dump = writeDump(jsonl);
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try (GZIPOutputStream gzip = new GZIPOutputStream(bos);
+             Writer writer = new OutputStreamWriter(gzip, StandardCharsets.UTF_8)) {
+            writer.write(jsonl);
+        }
+        Path dump = tmp.resolve("dump.jsonl.gz");
+        Files.write(dump, bos.toByteArray());
 
         // When
         List<WiktionaryEntry> result;
@@ -50,7 +56,13 @@ class JsonlDictionaryParserTest {
         // Given
         String jsonl = "{\"word\":\"\",\"lang_code\":\"el\",\"senses\":[]}\n"
                 + "{\"word\":\"καλή\",\"lang_code\":\"el\",\"senses\":[]}\n";
-        Path dump = writeDump(jsonl);
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try (GZIPOutputStream gzip = new GZIPOutputStream(bos);
+             Writer writer = new OutputStreamWriter(gzip, StandardCharsets.UTF_8)) {
+            writer.write(jsonl);
+        }
+        Path dump = tmp.resolve("dump.jsonl.gz");
+        Files.write(dump, bos.toByteArray());
 
         // When
         List<WiktionaryEntry> result;
@@ -62,16 +74,5 @@ class JsonlDictionaryParserTest {
         assertThat(result)
                 .extracting(WiktionaryEntry::word)
                 .containsExactly("καλή");
-    }
-
-    private Path writeDump(String jsonl) throws Exception {
-        ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        try (GZIPOutputStream gzip = new GZIPOutputStream(bos);
-             Writer writer = new OutputStreamWriter(gzip, StandardCharsets.UTF_8)) {
-            writer.write(jsonl);
-        }
-        Path dump = tmp.resolve("dump.jsonl.gz");
-        Files.write(dump, bos.toByteArray());
-        return dump;
     }
 }

--- a/src/test/java/edu/self/w2k/render/HtmlDefinitionRendererTest.java
+++ b/src/test/java/edu/self/w2k/render/HtmlDefinitionRendererTest.java
@@ -1,100 +1,69 @@
 package edu.self.w2k.render;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
+import edu.self.w2k.model.WiktionaryExample;
+import edu.self.w2k.model.WiktionarySense;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
 class HtmlDefinitionRendererTest {
 
-    private final DefinitionRenderer renderer = new HtmlDefinitionRenderer();
+    private final HtmlDefinitionRenderer unit = new HtmlDefinitionRenderer();
 
     @Test
-    void buildDefinition_basicGloss() {
-        var senses = List.of(parseSense("{\"glosses\":[\"a dog\"],\"examples\":[]}"));
-        var def = renderer.render(senses);
-        assertTrue(def.isPresent());
-        assertTrue(def.get().contains("<ol>"), "should wrap in <ol>");
-        assertTrue(def.get().contains("<li><span>a dog</span>"), "should contain gloss");
-        assertFalse(def.get().contains("<ul>"), "no examples → no <ul>");
+    void should_render_html_with_glosses_and_examples_when_senses_have_content() {
+        // Given
+        WiktionaryExample example = new WiktionaryExample("The apple fell from the tree.");
+        WiktionarySense sense = new WiktionarySense(List.of("A round fruit"), List.of(example));
+
+        // When
+        Optional<String> result = unit.render(List.of(sense));
+
+        // Then
+        assertThat(result).isPresent();
+        String html = result.get();
+        assertThat(html)
+                .startsWith("<ol>")
+                .contains("<li><span>")
+                .contains("A round fruit")
+                .contains("<ul>")
+                .contains("<li>The apple fell from the tree.</li>")
+                .endsWith("</ol>");
     }
 
     @Test
-    void buildDefinition_xmlEscaping() {
-        var senses = List.of(parseSense("{\"glosses\":[\"bread & butter <food>\"],\"examples\":[]}"));
-        var def = renderer.render(senses);
-        assertTrue(def.isPresent());
-        assertTrue(def.get().contains("bread &amp; butter &lt;food&gt;"), "XML characters should be escaped");
+    void should_return_empty_when_no_glosses_have_content() {
+        // Given
+        WiktionarySense emptyGloss = new WiktionarySense(List.of("", "  "), List.of());
+        WiktionarySense nullGloss = new WiktionarySense(List.of(), List.of());
+
+        // When
+        Optional<String> result = unit.render(List.of(emptyGloss, nullGloss));
+
+        // Then
+        assertThat(result).isEmpty();
     }
 
     @Test
-    void buildDefinition_withExample() {
-        var senses = List.of(parseSense("{\"glosses\":[\"run\"],\"examples\":[{\"text\":\"He runs fast.\"}]}"));
-        var def = renderer.render(senses);
-        assertTrue(def.isPresent());
-        assertTrue(def.get().contains("<ul>"), "examples present → <ul>");
-        assertTrue(def.get().contains("<li>He runs fast.</li>"));
-    }
+    void should_escape_xml_and_replace_newlines_when_rendering() {
+        // Given
+        WiktionarySense sense = new WiktionarySense(List.of("A & B\nC"), List.of());
 
-    @Test
-    void buildDefinition_stripsNewlines() {
-        var senses = List.of(parseSense("{\"glosses\":[\"line1\\nline2\"],\"examples\":[]}"));
-        var def = renderer.render(senses);
-        assertTrue(def.isPresent());
-        assertTrue(def.get().contains("line1; line2"), "newlines should be replaced with '; '");
-    }
+        // When
+        Optional<String> result = unit.render(List.of(sense));
 
-    @Test
-    void buildDefinition_multipleGlossesInOneSense() {
-        var senses = List.of(parseSense("{\"glosses\":[\"first meaning\",\"second meaning\"],\"examples\":[]}"));
-        var def = renderer.render(senses);
-        assertTrue(def.isPresent());
-        assertTrue(def.get().contains("first meaning"));
-        assertTrue(def.get().contains("second meaning"));
-    }
-
-    @Test
-    void buildDefinition_nullSensesSkipped() {
-        var senses = List.of(parseSense("{\"glosses\":[],\"examples\":[]}"));
-        assertTrue(renderer.render(senses).isEmpty(), "form_of-only entries should return empty Optional");
-    }
-
-    @Test
-    void buildDefinition_blankGlossSkipped() {
-        var senses = List.of(parseSense("{\"glosses\":[\"  \"],\"examples\":[]}"));
-        assertTrue(renderer.render(senses).isEmpty(), "blank gloss should be skipped → empty Optional");
-    }
-
-    @Test
-    void buildDefinition_blankExampleSkipped() {
-        var senses = List.of(parseSense("{\"glosses\":[\"gloss\"],\"examples\":[{\"text\":\"  \"}]}"));
-        var def = renderer.render(senses);
-        assertTrue(def.isPresent());
-        assertFalse(def.get().contains("<ul>"), "blank example should be skipped → no <ul>");
-    }
-
-    @Test
-    void buildDefinition_greekContent() {
-        var senses = List.of(parseSense("{\"glosses\":[\"σκύλος (dog)\"],\"examples\":[{\"text\":\"Ο σκύλος τρέχει.\"}]}"));
-        var def = renderer.render(senses);
-        assertTrue(def.isPresent());
-        assertTrue(def.get().contains("σκύλος (dog)"), "Greek gloss should pass through unchanged");
-        assertTrue(def.get().contains("Ο σκύλος τρέχει."), "Greek example should pass through unchanged");
-    }
-
-    // ── helpers ──────────────────────────────────────────────────────────────
-
-    private static edu.self.w2k.model.WiktionarySense parseSense(String json) {
-        try {
-            return new com.fasterxml.jackson.databind.ObjectMapper()
-                    .readerFor(edu.self.w2k.model.WiktionarySense.class)
-                    .readValue(json);
-        }
-        catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        // Then
+        assertThat(result).isPresent();
+        String html = result.get();
+        assertThat(html)
+                .contains("&amp;")
+                .contains("; ")
+                .doesNotContain("\n");
     }
 }

--- a/src/test/java/edu/self/w2k/write/DictionaryTitlesTest.java
+++ b/src/test/java/edu/self/w2k/write/DictionaryTitlesTest.java
@@ -11,7 +11,7 @@ class DictionaryTitlesTest {
 
     @Test
     void should_use_display_names_when_lang_codes_are_known() {
-        // Given / When
+        // When
         String result = DictionaryTitles.autoTitle("el", "en");
 
         // Then
@@ -24,7 +24,7 @@ class DictionaryTitlesTest {
 
     @Test
     void should_uppercase_when_lang_code_is_unknown() {
-        // Given / When
+        // When
         String result = DictionaryTitles.autoTitle("xx", "yy");
 
         // Then

--- a/src/test/java/edu/self/w2k/write/DictionaryTitlesTest.java
+++ b/src/test/java/edu/self/w2k/write/DictionaryTitlesTest.java
@@ -1,22 +1,33 @@
 package edu.self.w2k.write;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
 class DictionaryTitlesTest {
 
     @Test
-    void autoTitle_knownLanguageCodes() {
-        String title = DictionaryTitles.autoTitle("fr", "en");
-        assertTrue(title.contains("French"), "should contain 'French', got: " + title);
-        assertTrue(title.contains("English"), "should contain 'English', got: " + title);
-        assertTrue(title.endsWith("Dictionary"), "should end with 'Dictionary'");
+    void should_use_display_names_when_lang_codes_are_known() {
+        // Given / When
+        String result = DictionaryTitles.autoTitle("el", "en");
+
+        // Then
+        assertThat(result)
+                .contains("Greek")
+                .contains("English")
+                .contains("–")
+                .endsWith("Dictionary");
     }
 
     @Test
-    void autoTitle_unknownCodeFallsBackToUpperCase() {
-        String title = DictionaryTitles.autoTitle("xx", "en");
-        assertTrue(title.contains("XX"), "unknown code should fall back to upper-case, got: " + title);
+    void should_uppercase_when_lang_code_is_unknown() {
+        // Given / When
+        String result = DictionaryTitles.autoTitle("xx", "yy");
+
+        // Then
+        assertThat(result).startsWith("XX").endsWith("Dictionary");
     }
 }

--- a/src/test/java/edu/self/w2k/write/opf/HtmlChapterRendererTest.java
+++ b/src/test/java/edu/self/w2k/write/opf/HtmlChapterRendererTest.java
@@ -1,133 +1,55 @@
 package edu.self.w2k.write.opf;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
-
-import org.junit.jupiter.api.Test;
 
 import edu.self.w2k.model.LexiconEntry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
 class HtmlChapterRendererTest {
 
     @Test
-    void render_containsKindleNamespaces() {
-        String html = render(entry("word", "def"));
-        assertTrue(html.contains("xmlns:mbp=\"" + HtmlChapterRenderer.KINDLE_NS + "\""),
-                "mbp namespace must be present");
-        assertTrue(html.contains("xmlns:idx=\"" + HtmlChapterRenderer.KINDLE_NS + "\""),
-                "idx namespace must be present");
-    }
-
-    @Test
-    void render_correctEntryStructure() {
-        String html = render(entry("hello", "<ol><li>a greeting</li></ol>"));
-        assertTrue(html.contains("<idx:entry name=\"word\" scriptable=\"yes\">"),
-                "entry element must have correct attributes");
-        assertTrue(html.contains("<idx:orth value=\"hello\">"),
-                "orth value must equal display term");
-        assertTrue(html.contains("<b>hello</b>"), "display term in <b>");
-        assertTrue(html.contains("<ol><li>a greeting</li></ol>"), "definition passed through");
-    }
-
-    @Test
-    void render_sortedEntriesPreserveOrder() {
-        // TreeMap guarantees alphabetical order — verify it is preserved in output
-        TreeMap<String, List<LexiconEntry>> defs = buildDefs(
-                "zebra\t<ol><li>animal</li></ol>",
-                "apple\t<ol><li>fruit</li></ol>",
-                "mango\t<ol><li>fruit</li></ol>");
-        String html = renderDefs(defs);
-
-        int applePos = html.indexOf("value=\"apple\"");
-        int mangoPos = html.indexOf("value=\"mango\"");
-        int zebraPos = html.indexOf("value=\"zebra\"");
-        assertTrue(applePos < mangoPos, "apple before mango");
-        assertTrue(mangoPos < zebraPos, "mango before zebra");
-    }
-
-    @Test
-    void render_valueMatchesDisplayTerm() {
-        // value attribute must match the visible display term so kindling can locate entries in the text blob
+    void should_render_kindle_idx_entries_when_called() {
+        // Given
         List<Map.Entry<String, List<LexiconEntry>>> entries = List.of(
-                Map.entry("hello", List.of(new LexiconEntry("Hello", "<ol><li>greet</li></ol>"))));
-        String html = new String(HtmlChapterRenderer.render(entries), StandardCharsets.UTF_8);
-        assertTrue(html.contains("value=\"Hello\""), "value must match display term (original case)");
-        assertTrue(html.contains("<b>Hello</b>"), "display term in <b>");
+                Map.entry("apple", List.of(new LexiconEntry("apple", "<ol><li>fruit</li></ol>"))),
+                Map.entry("banana", List.of(new LexiconEntry("banana", "<ol><li>tropical fruit</li></ol>")))
+        );
+
+        // When
+        byte[] bytes = HtmlChapterRenderer.render(entries);
+        String html = new String(bytes, StandardCharsets.UTF_8);
+
+        // Then
+        assertThat(html)
+                .contains("xmlns:idx")
+                .contains("xmlns:mbp")
+                .contains("<idx:entry name=\"word\"")
+                .contains("<idx:orth value=\"apple\">")
+                .contains("<b>apple</b>");
     }
 
     @Test
-    void render_sameKeyEntriesJoined() {
-        List<LexiconEntry> entries = new ArrayList<>();
-        entries.add(new LexiconEntry("Apple", "<ol><li>a fruit</li></ol>"));
-        entries.add(new LexiconEntry("apple", "<ol><li>a tech company</li></ol>"));
-        TreeMap<String, List<LexiconEntry>> defs = new TreeMap<>();
-        defs.put("apple", entries);
+    void should_combine_definitions_with_semicolons_when_multiple_entries_share_key() {
+        // Given
+        List<Map.Entry<String, List<LexiconEntry>>> entries = List.of(
+                Map.entry("word", List.of(
+                        new LexiconEntry("word", "def1"),
+                        new LexiconEntry("word", "def2")
+                ))
+        );
 
-        String html = renderDefs(defs);
-        long entryCount = html.lines().filter(l -> l.contains("<idx:entry name=\"word\"")).count();
-        assertEquals(1, entryCount, "same key → one idx:entry");
-        assertTrue(html.contains("a fruit"), "first def present");
-        assertTrue(html.contains("a tech company"), "second def present");
-        assertTrue(html.indexOf("a fruit") < html.indexOf("a tech company"),
-                "definitions joined in insertion order");
-    }
+        // When
+        byte[] bytes = HtmlChapterRenderer.render(entries);
+        String html = new String(bytes, StandardCharsets.UTF_8);
 
-    @Test
-    void render_singleEntryProducesOneIdxEntry() {
-        String html = render(entry("hello", "<ol><li>a greeting</li></ol>"));
-        long count = html.lines().filter(l -> l.contains("<idx:entry name=\"word\"")).count();
-        assertEquals(1, count, "single entry → one idx:entry");
-    }
-
-    @Test
-    void render_chunkSplitAt10001() {
-        TreeMap<String, List<LexiconEntry>> defs = new TreeMap<>();
-        for (int i = 0; i <= 10_000; i++) {
-            String w = "word%05d".formatted(i);
-            defs.put(w, List.of(new LexiconEntry(w, "<ol><li>def</li></ol>")));
-        }
-        List<Map.Entry<String, List<LexiconEntry>>> all = new ArrayList<>(defs.entrySet());
-        // First chunk: 10_000 entries
-        String first = new String(HtmlChapterRenderer.render(all.subList(0, 10_000)), StandardCharsets.UTF_8);
-        // Second chunk: 1 entry
-        String second = new String(HtmlChapterRenderer.render(all.subList(10_000, 10_001)), StandardCharsets.UTF_8);
-
-        long firstCount = first.lines().filter(l -> l.contains("<idx:entry name=\"word\"")).count();
-        long secondCount = second.lines().filter(l -> l.contains("<idx:entry name=\"word\"")).count();
-        assertEquals(10_000, firstCount, "first chunk has 10,000 entries");
-        assertEquals(1, secondCount, "second chunk has 1 entry");
-    }
-
-    // ── helpers ───────────────────────────────────────────────────────────────
-
-    private static String render(Map.Entry<String, List<LexiconEntry>> entry) {
-        return new String(HtmlChapterRenderer.render(List.of(entry)), StandardCharsets.UTF_8);
-    }
-
-    private static String renderDefs(TreeMap<String, List<LexiconEntry>> defs) {
-        return new String(HtmlChapterRenderer.render(new ArrayList<>(defs.entrySet())),
-                StandardCharsets.UTF_8);
-    }
-
-    private static Map.Entry<String, List<LexiconEntry>> entry(String key, String def) {
-        return Map.entry(key, List.of(new LexiconEntry(key, def)));
-    }
-
-    private static TreeMap<String, List<LexiconEntry>> buildDefs(String... lines) {
-        TreeMap<String, List<LexiconEntry>> defs = new TreeMap<>();
-        for (String line : lines) {
-            int tab = line.indexOf('\t');
-            if (tab < 0) continue;
-            String term = line.substring(0, tab).strip();
-            String defn = line.substring(tab + 1);
-            defs.computeIfAbsent(term, k -> new ArrayList<>()).add(new LexiconEntry(term, defn));
-        }
-        return defs;
+        // Then
+        assertThat(html).contains("def1; def2");
     }
 }

--- a/src/test/java/edu/self/w2k/write/opf/OpfDictionaryWriterTest.java
+++ b/src/test/java/edu/self/w2k/write/opf/OpfDictionaryWriterTest.java
@@ -1,115 +1,61 @@
 package edu.self.w2k.write.opf;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.TreeMap;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-import org.w3c.dom.Document;
-import org.w3c.dom.NodeList;
-
 import edu.self.w2k.model.LexiconEntry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
 class OpfDictionaryWriterTest {
 
-    private final OpfDictionaryWriter writer = new OpfDictionaryWriter();
+    private final OpfDictionaryWriter unit = new OpfDictionaryWriter();
+
+    @TempDir
+    Path tmp;
 
     @Test
-    void write_returnsOpfPath(@TempDir Path tempDir) throws Exception {
-        Path opf = writer.write(buildDefs("alpha\tdef1", "beta\tdef2", "gamma\tdef3"),
-                "el", "en", "Test", tempDir);
-        assertEquals(tempDir.resolve("dictionary-el-en.opf"), opf);
-    }
-
-    @Test
-    void write_opfHasDictionaryLanguageTags(@TempDir Path tempDir) throws Exception {
-        Path opf = writer.write(buildDefs("alpha\tdef1"), "el", "en", "Test", tempDir);
-        Document doc = parseXml(opf);
-
-        NodeList inLang = doc.getElementsByTagName("DictionaryInLanguage");
-        NodeList outLang = doc.getElementsByTagName("DictionaryOutLanguage");
-        assertEquals(1, inLang.getLength(), "DictionaryInLanguage must appear once");
-        assertEquals("el", inLang.item(0).getTextContent(), "DictionaryInLanguage must be el");
-        assertEquals(1, outLang.getLength(), "DictionaryOutLanguage must appear once");
-        assertEquals("en", outLang.item(0).getTextContent(), "DictionaryOutLanguage must be en");
-    }
-
-    @Test
-    void write_manifestItemsHrefToExistingHtmlFiles(@TempDir Path tempDir) throws Exception {
-        Path opf = writer.write(buildDefs("alpha\tdef1", "beta\tdef2"), "el", "en", "Test", tempDir);
-        Document doc = parseXml(opf);
-
-        NodeList items = doc.getElementsByTagName("item");
-        assertTrue(items.getLength() > 0, "manifest must contain at least one item");
-        for (int i = 0; i < items.getLength(); i++) {
-            String href = items.item(i).getAttributes().getNamedItem("href").getNodeValue();
-            assertTrue(Files.exists(tempDir.resolve(href)),
-                    "Referenced HTML file must exist: " + href);
-        }
-    }
-
-    @Test
-    void write_htmlFilesContainKindleMarkup(@TempDir Path tempDir) throws Exception {
-        writer.write(buildDefs("alpha\tdef1"), "el", "en", "Test", tempDir);
-
-        List<Path> htmlFiles = new ArrayList<>();
-        try (var stream = Files.newDirectoryStream(tempDir, "*.html")) {
-            for (Path p : stream) htmlFiles.add(p);
-        }
-        assertTrue(htmlFiles.size() >= 1, "at least one HTML file must be created");
-        for (Path html : htmlFiles) {
-            String content = Files.readString(html);
-            assertTrue(content.contains("xmlns:idx"), "HTML must declare xmlns:idx");
-            assertTrue(content.contains("<idx:entry"), "HTML must contain idx:entry");
-        }
-    }
-
-    @Test
-    void write_moreThan10000KeysProduceMultipleHtmlFiles(@TempDir Path tempDir) throws Exception {
+    void should_write_opf_html_and_return_opf_path_when_called() throws Exception {
+        // Given
         TreeMap<String, List<LexiconEntry>> defs = new TreeMap<>();
-        for (int i = 0; i <= 10_000; i++) {
-            String w = "word%05d".formatted(i);
-            defs.put(w, List.of(new LexiconEntry(w, "<ol><li>def</li></ol>")));
-        }
+        defs.put("apple", List.of(new LexiconEntry("apple", "<ol><li>fruit</li></ol>")));
+        defs.put("banana", List.of(new LexiconEntry("banana", "<ol><li>tropical fruit</li></ol>")));
+        defs.put("cherry", List.of(new LexiconEntry("cherry", "<ol><li>small fruit</li></ol>")));
 
-        writer.write(defs, "el", "en", "Test", tempDir);
+        // When
+        Path result = unit.write(defs, "en", "fr", "English-French Dictionary", tmp);
 
-        List<Path> htmlFiles = new ArrayList<>();
-        try (var stream = Files.newDirectoryStream(tempDir, "*.html")) {
-            for (Path p : stream) htmlFiles.add(p);
-        }
-        assertTrue(htmlFiles.size() >= 2, "10,001 entries must produce at least 2 HTML files");
+        // Then
+        assertThat(result).isEqualTo(tmp.resolve("dictionary-en-fr.opf"));
+        assertThat(result).exists();
+        String opfContent = Files.readString(result);
+        assertThat(opfContent)
+                .contains("<DictionaryInLanguage>en</DictionaryInLanguage>")
+                .contains("<DictionaryOutLanguage>fr</DictionaryOutLanguage>");
+        assertThat(tmp.resolve("dictionary-en-fr-0.html")).exists();
     }
 
-    // ── helpers ───────────────────────────────────────────────────────────────
-
-    private static Document parseXml(Path path) throws Exception {
-        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-        factory.setNamespaceAware(false);
-        // Disable external entity processing (not needed here, also safer)
-        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-        DocumentBuilder builder = factory.newDocumentBuilder();
-        return builder.parse(path.toFile());
-    }
-
-    private static TreeMap<String, List<LexiconEntry>> buildDefs(String... lines) {
+    @Test
+    void should_chunk_html_files_when_entries_exceed_chapter_limit() throws Exception {
+        // Given
         TreeMap<String, List<LexiconEntry>> defs = new TreeMap<>();
-        for (String line : lines) {
-            int tab = line.indexOf('\t');
-            if (tab < 0) continue;
-            String term = line.substring(0, tab).strip();
-            String defn = line.substring(tab + 1);
-            defs.computeIfAbsent(term, k -> new ArrayList<>()).add(new LexiconEntry(term, defn));
+        for (int i = 0; i <= HtmlChapterRenderer.ENTRIES_PER_CHAPTER; i++) {
+            String key = String.format("word%05d", i);
+            defs.put(key, List.of(new LexiconEntry(key, "<ol><li>def</li></ol>")));
         }
-        return defs;
+
+        // When
+        unit.write(defs, "en", "fr", "English-French Dictionary", tmp);
+
+        // Then
+        assertThat(tmp.resolve("dictionary-en-fr-0.html")).exists();
+        assertThat(tmp.resolve("dictionary-en-fr-1.html")).exists();
     }
 }

--- a/src/test/java/edu/self/w2k/write/opf/OpfDictionaryWriterTest.java
+++ b/src/test/java/edu/self/w2k/write/opf/OpfDictionaryWriterTest.java
@@ -33,8 +33,9 @@ class OpfDictionaryWriterTest {
         Path result = unit.write(defs, "en", "fr", "English-French Dictionary", tmp);
 
         // Then
-        assertThat(result).isEqualTo(tmp.resolve("dictionary-en-fr.opf"));
-        assertThat(result).exists();
+        assertThat(result)
+                .isEqualTo(tmp.resolve("dictionary-en-fr.opf"))
+                .exists();
         String opfContent = Files.readString(result);
         assertThat(opfContent)
                 .contains("<DictionaryInLanguage>en</DictionaryInLanguage>")


### PR DESCRIPTION
## Summary

- Replaces all hand-written stubs and bare JUnit assertions with a uniform Mockito + AssertJ unit-test suite (32 tests across 13 test classes)
- Adds `mockito-core`, `mockito-junit-jupiter`, and `assertj-core` to `pom.xml`
- Refactors `KaikkiDumpDownloader` to accept `HttpClient` and `Path dumpsDir` via a package-private constructor, mirroring the `KindlingDownloader` pattern, so the downloader is unit-testable without network access
- Updates `docs/test-rewrite-plan.md` to document a JDK 25 quirk: `DateTimeFormatter.RFC_1123_DATE_TIME` does not parse leniently when the day-of-week mismatches the calendar date

## Test plan

- [ ] `mvn clean test` — all 32 tests pass
- [ ] `mvn package` — fat JAR builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)