### PR TITLE
ci: skip sonar when SONAR_TOKEN is unavailable

### DIFF
--- a/.github/workflows/java-ci.yaml
+++ b/.github/workflows/java-ci.yaml
@@ -15,6 +15,8 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
@@ -26,7 +28,9 @@ jobs:
           distribution: temurin
           cache: maven
 
-      - run: mvn --no-transfer-progress verify sonar:sonar
+      - run: mvn --no-transfer-progress verify
+
+      - run: mvn --no-transfer-progress sonar:sonar
+        if: env.SONAR_TOKEN != ''
         env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes the build failure on Renovate's PR #50.

## Root cause

The CI workflow ran `mvn verify sonar:sonar` in a single step. GitHub withholds secrets on PRs from third-party bots (Renovate), so `SONAR_TOKEN` is empty, causing SonarCloud to return 403 and fail the build.

## Fix

- Split into two Maven steps: `mvn verify` (always runs) and `mvn sonar:sonar` (skipped when `SONAR_TOKEN` is empty)
- `SONAR_TOKEN` is set as a job-level env var so it can be checked in the step's `if` condition