### PR TITLE
chore(deps): update kindling-cli to v0.28.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,7 +32,7 @@ java -jar target/wiktionary-to-kindle-1.0.0.jar download fr     # French edition
 # The latest dump matching DUMP_LANG in dumps/ is auto-discovered.
 java -jar target/wiktionary-to-kindle-1.0.0.jar generate <DUMP_LANG> <WORD_LANG>
 java -jar target/wiktionary-to-kindle-1.0.0.jar generate el en                        # auto-downloads kindling-cli on first run
-java -jar target/wiktionary-to-kindle-1.0.0.jar generate el en --kindling-version v0.14.5
+java -jar target/wiktionary-to-kindle-1.0.0.jar generate el en --kindling-version v0.28.0
 java -jar target/wiktionary-to-kindle-1.0.0.jar generate el en --kindling-cli /usr/local/bin/kindling-cli
 # gen is a short alias for generate
 

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ On first run, `kindling-cli` is downloaded automatically from GitHub Releases an
 # Produces dictionaries/dictionary-el-en.mobi (plus .opf and .html side-artefacts)
 java -jar target/wiktionary-to-kindle-1.0.0.jar generate el en
 
-# Pin a specific kindling release (default: v0.14.5)
-java -jar target/wiktionary-to-kindle-1.0.0.jar generate el en --kindling-version v0.14.5
+# Pin a specific kindling release (default: v0.28.0)
+java -jar target/wiktionary-to-kindle-1.0.0.jar generate el en --kindling-version v0.28.0
 
 # Use a pre-installed kindling-cli binary (skips download)
 java -jar target/wiktionary-to-kindle-1.0.0.jar generate el en --kindling-cli /usr/local/bin/kindling-cli

--- a/src/main/java/edu/self/w2k/kindling/KindlingRelease.java
+++ b/src/main/java/edu/self/w2k/kindling/KindlingRelease.java
@@ -4,23 +4,23 @@ import java.util.Map;
 
 public final class KindlingRelease {
 
-    public static final String DEFAULT_VERSION = "v0.14.5";
+    public static final String DEFAULT_VERSION = "v0.28.0";
 
     public record Asset(String fileName, String sha256) {}
 
     public static final Map<KindlingPlatform, Asset> DEFAULT_ASSETS = Map.of(
             KindlingPlatform.LINUX_X64,
                 new Asset("kindling-cli-linux",
-                        "11369537b1d82bd835a06ffa940e8e75a5ee034e5eaee5d7ff4352c15b66f137"),
+                        "de9b13813100e246ab5681e4d82b78e6c6f4248337cee17ae38ff4165ef11266"),
             KindlingPlatform.MAC_APPLE_SILICON,
                 new Asset("kindling-cli-mac-apple-silicon",
-                        "ac15153df818e4fea2608627a5f5cb2ee59f762be02c535160a8b6871f29ea3c"),
+                        "889ea08dca2ebd5d39c39ac2a03f0e59351185a6229c170fca0a9689df9e0bfb"),
             KindlingPlatform.MAC_INTEL,
                 new Asset("kindling-cli-mac-intel",
-                        "a7d1657beacd30ec6016caf44b1738bad679783a06ef8dd6a08b9a961a9bc0c6"),
+                        "a22d6d76cea226bcfd724489d219b56d5fcf5989cf925bb726fb77961a1cc24e"),
             KindlingPlatform.WINDOWS_X64,
                 new Asset("kindling-cli-windows.exe",
-                        "dc06c1059682949eacc17d49c1ebb03c1b70a60ca8c2b8f0f508ba0fe622d62c"));
+                        "64d6a32b169ddc552c2695367ec3091848223f2c68c356a057a9d2cd2faedf79"));
 
     private KindlingRelease() {}
 }

--- a/src/test/java/edu/self/w2k/kindling/KindlingCliResolverTest.java
+++ b/src/test/java/edu/self/w2k/kindling/KindlingCliResolverTest.java
@@ -40,7 +40,7 @@ class KindlingCliResolverTest {
         Path executable = Files.createFile(tmp.resolve("kindling-cli"));
         executable.toFile().setExecutable(true);
         KindlingCliResolver unit = new KindlingCliResolver(
-                "v0.14.5", Optional.of(executable), downloader, pathProbe, digestProvider);
+                "v0.28.0", Optional.of(executable), downloader, pathProbe, digestProvider);
 
         // When
         Path result = unit.resolve();
@@ -57,7 +57,7 @@ class KindlingCliResolverTest {
         executableOnPath.toFile().setExecutable(true);
         when(pathProbe.apply("kindling-cli")).thenReturn(Optional.of(executableOnPath));
         KindlingCliResolver unit = new KindlingCliResolver(
-                "v0.14.5", Optional.empty(), downloader, pathProbe, digestProvider);
+                "v0.28.0", Optional.empty(), downloader, pathProbe, digestProvider);
 
         // When
         Path result = unit.resolve();


### PR DESCRIPTION
Bumps the pinned `kindling-cli` release from **v0.14.5** (2026-04-24) to **v0.28.0** (2026-07-13) and refreshes the per-platform SHA-256 digests in `KindlingRelease.DEFAULT_ASSETS`.

## Compatibility

The `kindling-cli build <opf> -o <mobi>` invocation is unchanged across all intervening releases, so `KindlingDictionaryConverter` needs no adjustment.

## Why this matters for this project

The releases between v0.14.5 and v0.28.0 are largely dictionary-index correctness fixes, several of which affect the MOBI output this tool produces:

| Release | Fix |
|---|---|
| v0.18.0 | Blank lookup page for the first headword of any dictionary with front matter — affected Latin-script dictionaries too |
| v0.18.2 | Multi-leaf routing entries for dictionaries spanning more than one 64000-byte orth leaf. Full Wiktionary dumps are far larger than a single leaf, so cross-leaf lookups were broken |
| v0.18.3 | 16-character truncation cliff in orth/inflection labels — long headwords were lost or collided with their own inflections |
| v0.21.0 | Latin-script collation reworked to exact accent matching; fixes accent-initial headword sorting |
| v0.16.0–v0.22.0 | Generated-ORDT collation for ja/zh/ko/ar and RTL scripts |

## Verification

- `mvn clean verify` — 57 tests pass.
- Digests are taken from the GitHub release API `digest` field, which is the same source `KindlingDownloader.resolveDigest()` already trusts for non-pinned versions.

## Files touched

- `KindlingRelease.java` — version + four digests
- `KindlingCliResolverTest.java` — version string in fixtures
- `README.md`, `.github/copilot-instructions.md` — documented default version

🤖 Generated with [Claude Code](https://claude.com/claude-code)