### PR TITLE
ci: auto-merge kindling update PRs when required checks pass

### DIFF
--- a/.github/workflows/update-kindling.yaml
+++ b/.github/workflows/update-kindling.yaml
@@ -37,6 +37,7 @@ jobs:
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        id: cpr
         with:
           token: ${{ secrets.WIKTIONARY_KINDLING }}
           commit-message: 'chore(deps): update kindling-cli to ${{ steps.release.outputs.tag }}'
@@ -52,3 +53,9 @@ jobs:
             non-pinned versions. No binaries are downloaded by this workflow.
 
             Automated by `.github/workflows/update-kindling.yaml`.
+
+      - name: Enable auto-merge
+        if: steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated'
+        env:
+          GH_TOKEN: ${{ secrets.WIKTIONARY_KINDLING }}
+        run: gh pr merge --auto --squash "${{ steps.cpr.outputs.pull-request-number }}" --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
## Summary

Adds an `Enable auto-merge` step after `create-pull-request`: when a kindling bump PR is created or updated, the workflow runs `gh pr merge --auto --squash` on it (authenticated with the same `WIKTIONARY_KINDLING` PAT). GitHub then merges the PR automatically once the `master` ruleset's required `build` check passes; if the build fails, the PR simply stays open.

Also enabled the repo setting **Allow auto-merge** (Settings → General → Pull Requests), which this feature requires — done directly, since it's a settings toggle, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)