### PR TITLE
feat(progress): add progress and cancellation seams to the pipeline

### DIFF
--- a/src/main/java/edu/self/w2k/CLI.java
+++ b/src/main/java/edu/self/w2k/CLI.java
@@ -1,5 +1,6 @@
 package edu.self.w2k;
 
+import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -81,8 +82,14 @@ public class CLI implements Callable<Integer> {
 
         @Override
         public Integer call() {
-            new DownloadCommand(new KaikkiDumpDownloader(lang)).run();
-            return 0;
+            try {
+                new DownloadCommand(new KaikkiDumpDownloader(lang)).run();
+                return 0;
+            }
+            catch (IOException e) {
+                log.error("Download failed: {}", e.getLocalizedMessage());
+                return 1;
+            }
         }
     }
 

--- a/src/main/java/edu/self/w2k/command/DownloadCommand.java
+++ b/src/main/java/edu/self/w2k/command/DownloadCommand.java
@@ -1,5 +1,8 @@
 package edu.self.w2k.command;
 
+import java.io.IOException;
+
+import edu.self.w2k.download.DownloadResult;
 import edu.self.w2k.download.DumpDownloader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,7 +14,15 @@ public class DownloadCommand implements Command {
     private final DumpDownloader downloader;
 
     @Override
-    public void run() {
-        downloader.download();
+    public void run() throws IOException {
+        execute();
+    }
+
+    /**
+     * Same work as {@link #run()}, but surfaces where the dump landed. The GUI chains straight into
+     * generation and so needs the path, rather than re-globbing the dumps directory for it.
+     */
+    public DownloadResult execute() throws IOException {
+        return downloader.download();
     }
 }

--- a/src/main/java/edu/self/w2k/command/GenerateCommand.java
+++ b/src/main/java/edu/self/w2k/command/GenerateCommand.java
@@ -1,6 +1,8 @@
 package edu.self.w2k.command;
 
 import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -18,14 +20,14 @@ import java.util.stream.Stream;
 
 import edu.self.w2k.model.LexiconEntry;
 import edu.self.w2k.parse.DictionaryParser;
+import edu.self.w2k.progress.ProgressListener;
+import edu.self.w2k.progress.ProgressListener.Stage;
 import edu.self.w2k.render.DefinitionRenderer;
 import edu.self.w2k.render.HtmlDefinitionRenderer;
 import edu.self.w2k.write.DictionaryWriter;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@RequiredArgsConstructor
 public class GenerateCommand implements Command {
 
     private final DictionaryParser parser;
@@ -36,6 +38,26 @@ public class GenerateCommand implements Command {
     private final String srcLang;
     private final String trgLang;
     private final String title;
+    private final ProgressListener progress;
+
+    public GenerateCommand(DictionaryParser parser, DefinitionRenderer renderer, DictionaryWriter writer,
+                           Path dumpFile, Path outputDir, String srcLang, String trgLang, String title) {
+        this(parser, renderer, writer, dumpFile, outputDir, srcLang, trgLang, title, ProgressListener.NOOP);
+    }
+
+    public GenerateCommand(DictionaryParser parser, DefinitionRenderer renderer, DictionaryWriter writer,
+                           Path dumpFile, Path outputDir, String srcLang, String trgLang, String title,
+                           ProgressListener progress) {
+        this.parser = parser;
+        this.renderer = renderer;
+        this.writer = writer;
+        this.dumpFile = dumpFile;
+        this.outputDir = outputDir;
+        this.srcLang = srcLang;
+        this.trgLang = trgLang;
+        this.title = title;
+        this.progress = progress;
+    }
 
     @Override
     public void run() throws IOException {
@@ -48,6 +70,12 @@ public class GenerateCommand implements Command {
                         .map(r -> new LexiconEntry(e.word(), r.html(), r.inflectionForms(), r.formOfLemmas()))
                         .stream())) {
             stream.forEach(e -> {
+                // The only cancellation point in the pipeline's longest stage: a multi-gigabyte dump
+                // takes tens of minutes to stream, and the GUI's cancel interrupts this thread.
+                if (Thread.currentThread().isInterrupted()) {
+                    throw new UncheckedIOException(
+                            new InterruptedIOException("Generation cancelled after %d entries".formatted(count.get())));
+                }
                 String key = normaliseKey(e.word());
                 if (!key.isEmpty()) {
                     grouped.computeIfAbsent(key, k -> new ArrayList<>()).add(e);
@@ -55,9 +83,13 @@ public class GenerateCommand implements Command {
                 }
             });
         }
+        catch (UncheckedIOException e) {
+            throw e.getCause();
+        }
 
         log.info("Done. {} entries grouped into {} unique keys for srcLang={}, trgLang={}", count.get(), grouped.size(), srcLang, trgLang);
 
+        progress.onProgress(Stage.FOLD, 0, ProgressListener.TOTAL_UNKNOWN);
         foldFormOfEntries(grouped);
         filterFormsCollidingWithHeadwords(grouped);
 

--- a/src/main/java/edu/self/w2k/download/DownloadResult.java
+++ b/src/main/java/edu/self/w2k/download/DownloadResult.java
@@ -1,0 +1,15 @@
+package edu.self.w2k.download;
+
+import java.nio.file.Path;
+
+/**
+ * Outcome of a successful {@link DumpDownloader#download()}.
+ * <p>
+ * A skipped download is a success, not a failure: {@code alreadyPresent} distinguishes "the dump was
+ * already on disk" from "the dump was transferred now", so callers can report accurately without
+ * having to re-glob the dumps directory. Genuine failures are signalled by an exception.
+ *
+ * @param dumpPath       the dump on disk, ready to be parsed
+ * @param alreadyPresent {@code true} when the transfer was skipped because the file already existed
+ */
+public record DownloadResult(Path dumpPath, boolean alreadyPresent) {}

--- a/src/main/java/edu/self/w2k/download/DumpDownloader.java
+++ b/src/main/java/edu/self/w2k/download/DumpDownloader.java
@@ -1,5 +1,15 @@
 package edu.self.w2k.download;
 
+import java.io.IOException;
+
 public interface DumpDownloader {
-    void download();
+
+    /**
+     * Downloads the dump, or reports it as already present.
+     *
+     * @return where the dump now lives, and whether it had to be transferred
+     * @throws java.io.InterruptedIOException if the calling thread was interrupted mid-transfer
+     * @throws IOException                    if the dump could not be obtained
+     */
+    DownloadResult download() throws IOException;
 }

--- a/src/main/java/edu/self/w2k/download/KaikkiDumpDownloader.java
+++ b/src/main/java/edu/self/w2k/download/KaikkiDumpDownloader.java
@@ -1,6 +1,9 @@
 package edu.self.w2k.download;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InterruptedIOException;
+import java.io.OutputStream;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpHeaders;
@@ -12,14 +15,12 @@ import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.OptionalLong;
 
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
+import edu.self.w2k.progress.ProgressListener;
+import edu.self.w2k.progress.ProgressListener.Stage;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public class KaikkiDumpDownloader implements DumpDownloader {
 
     private static final String BASE_URL = "https://kaikki.org";
@@ -34,27 +35,46 @@ public class KaikkiDumpDownloader implements DumpDownloader {
      */
     private static final Duration BODY_TIMEOUT = Duration.ofHours(6);
 
+    private static final long BYTES_PER_MB = 1024L * 1024L;
+    private static final int TRANSFER_BUFFER_BYTES = 64 * 1024;
+
+    /** Progress is emitted at most once per this many bytes, to keep listeners cheap. */
+    private static final long PROGRESS_INTERVAL_BYTES = 4 * BYTES_PER_MB;
+
     private final String lang;
     private final HttpClient httpClient;
     private final Path dumpsDir;
+    private final ProgressListener progress;
 
     public KaikkiDumpDownloader(String lang) {
-        this(lang,
-             HttpClient.newBuilder()
-                     .followRedirects(HttpClient.Redirect.NORMAL)
-                     .connectTimeout(Duration.ofSeconds(30))
-                     .build(),
-             Path.of("dumps"));
+        this(lang, Path.of("dumps"), ProgressListener.NOOP);
+    }
+
+    public KaikkiDumpDownloader(String lang, Path dumpsDir, ProgressListener progress) {
+        this(lang, defaultHttpClient(), dumpsDir, progress);
+    }
+
+    KaikkiDumpDownloader(String lang, HttpClient httpClient, Path dumpsDir) {
+        this(lang, httpClient, dumpsDir, ProgressListener.NOOP);
+    }
+
+    KaikkiDumpDownloader(String lang, HttpClient httpClient, Path dumpsDir, ProgressListener progress) {
+        this.lang = lang;
+        this.httpClient = httpClient;
+        this.dumpsDir = dumpsDir;
+        this.progress = progress;
+    }
+
+    private static HttpClient defaultHttpClient() {
+        return HttpClient.newBuilder()
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .connectTimeout(Duration.ofSeconds(30))
+                .build();
     }
 
     @Override
-    public void download() {
-        try {
-            Files.createDirectories(dumpsDir);
-        } catch (Exception e) {
-            log.error("Failed to create dump directory: {}", e.getLocalizedMessage(), e);
-            return;
-        }
+    public DownloadResult download() throws IOException {
+        Files.createDirectories(dumpsDir);
 
         String url = buildUrl(lang);
         log.info("Checking {}", url);
@@ -64,37 +84,76 @@ public class KaikkiDumpDownloader implements DumpDownloader {
         try {
             HttpResponse<Void> head = httpClient.send(headRequest(url), HttpResponse.BodyHandlers.discarding());
             if (head.statusCode() != 200) {
-                log.error("Download failed — HTTP {}", head.statusCode());
-                return;
+                throw new IOException("HTTP %d for %s".formatted(head.statusCode(), url));
             }
 
             String generatedDate = buildGeneratedDate(head.headers());
             Path dumpPath = dumpsDir.resolve("raw-wiktextract-data-%s-%s.jsonl.gz".formatted(lang, generatedDate));
             if (Files.exists(dumpPath)) {
                 log.info("Dump already exists at {}. Delete it to re-download.", dumpPath);
-                return;
+                return new DownloadResult(dumpPath, true);
             }
 
-            log.info("Downloading {} MB to {} (generated: {})", contentLengthMb(head.headers()), dumpPath, generatedDate);
-            HttpResponse<Path> response = httpClient.send(getRequest(url), HttpResponse.BodyHandlers.ofFile(partPath));
-            if (response.statusCode() != 200) {
-                log.error("Download failed — HTTP {}", response.statusCode());
-                return;
+            long total = contentLength(head.headers());
+            log.info("Downloading {} MB to {} (generated: {})", megabytes(total), dumpPath, generatedDate);
+
+            HttpResponse<InputStream> response =
+                    httpClient.send(getRequest(url), HttpResponse.BodyHandlers.ofInputStream());
+            try (InputStream body = response.body()) {
+                if (response.statusCode() != 200) {
+                    throw new IOException("HTTP %d for %s".formatted(response.statusCode(), url));
+                }
+                try (OutputStream out = Files.newOutputStream(partPath)) {
+                    transfer(body, out, total);
+                }
             }
 
             Files.move(partPath, dumpPath, StandardCopyOption.REPLACE_EXISTING);
-            log.info("Download complete: {} ({} MB, generated: {})", dumpPath, Files.size(dumpPath) / (1024 * 1024), generatedDate);
-        } catch (InterruptedException _) {
+            log.info("Download complete: {} ({} MB, generated: {})",
+                     dumpPath, Files.size(dumpPath) / BYTES_PER_MB, generatedDate);
+            return new DownloadResult(dumpPath, false);
+        }
+        catch (InterruptedException _) {
             Thread.currentThread().interrupt();
-            log.warn("Download interrupted for lang: {}", lang);
-        } catch (IOException e) {
-            log.error("Download failed", e);
-        } finally {
-            try {
-                Files.deleteIfExists(partPath);
-            } catch (IOException e) {
-                log.warn("Failed to delete partial file", e);
+            throw new InterruptedIOException("Download interrupted for lang: " + lang);
+        }
+        finally {
+            discardPartialFile(partPath);
+        }
+    }
+
+    /**
+     * Streams the body into {@code out}, reporting progress and honouring interruption. A manual loop
+     * is used rather than {@code BodyHandlers.ofFile}, which offers neither a byte-level callback nor
+     * a cancellation point. The atomic {@code .part} rename stays in the caller, unchanged.
+     */
+    private void transfer(InputStream in, OutputStream out, long total) throws IOException {
+        byte[] buffer = new byte[TRANSFER_BUFFER_BYTES];
+        long done = 0;
+        long lastReported = 0;
+
+        int read;
+        while ((read = in.read(buffer)) != -1) {
+            if (Thread.currentThread().isInterrupted()) {
+                throw new InterruptedIOException("Download cancelled after %d bytes".formatted(done));
             }
+            out.write(buffer, 0, read);
+            done += read;
+            if (done - lastReported >= PROGRESS_INTERVAL_BYTES) {
+                lastReported = done;
+                progress.onProgress(Stage.DOWNLOAD, done, total);
+            }
+        }
+        progress.onProgress(Stage.DOWNLOAD, done, total);
+    }
+
+    private static void discardPartialFile(Path partPath) {
+        try {
+            Files.deleteIfExists(partPath);
+        }
+        catch (IOException e) {
+            // Never mask the outcome of the download itself with a cleanup failure.
+            log.warn("Failed to delete partial file {}: {}", partPath, e.getLocalizedMessage());
         }
     }
 
@@ -113,9 +172,12 @@ public class KaikkiDumpDownloader implements DumpDownloader {
                 .build();
     }
 
-    private static String contentLengthMb(HttpHeaders headers) {
-        OptionalLong length = headers.firstValueAsLong("content-length");
-        return length.isPresent() ? Long.toString(length.getAsLong() / (1024 * 1024)) : "?";
+    private static long contentLength(HttpHeaders headers) {
+        return headers.firstValueAsLong("content-length").orElse(ProgressListener.TOTAL_UNKNOWN);
+    }
+
+    private static String megabytes(long bytes) {
+        return bytes < 0 ? "?" : Long.toString(bytes / BYTES_PER_MB);
     }
 
     private String buildGeneratedDate(HttpHeaders headers) {

--- a/src/main/java/edu/self/w2k/kindling/KindlingDictionaryConverter.java
+++ b/src/main/java/edu/self/w2k/kindling/KindlingDictionaryConverter.java
@@ -1,19 +1,23 @@
 package edu.self.w2k.kindling;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Locale;
 import java.util.TreeMap;
+import java.util.function.Consumer;
 
 import edu.self.w2k.model.LexiconEntry;
+import edu.self.w2k.progress.ProgressListener;
+import edu.self.w2k.progress.ProgressListener.Stage;
 import edu.self.w2k.write.DictionaryWriter;
 import edu.self.w2k.write.opf.OpfDictionaryWriter;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@RequiredArgsConstructor
 public class KindlingDictionaryConverter implements DictionaryWriter {
 
     @FunctionalInterface
@@ -21,13 +25,41 @@ public class KindlingDictionaryConverter implements DictionaryWriter {
         int run(List<String> command) throws IOException;
     }
 
+    /**
+     * Runs the binary and relays its output to the log.
+     * <p>
+     * Deliberately not {@code inheritIO()}: a windowed application has no terminal attached, so
+     * inherited output is discarded and kindling-cli failures become invisible. Pumping the merged
+     * streams through SLF4J instead means the output reaches the console for the CLI and the log pane
+     * for the GUI, with consistent formatting in both.
+     */
     public static ProcessRunner defaultRunner() {
+        return defaultRunner(_ -> {});
+    }
+
+    /**
+     * As {@link #defaultRunner()}, but hands the started process to {@code onStart} so a caller can
+     * destroy it on cancellation — {@code waitFor()} alone cannot be interrupted out of usefully,
+     * since interrupting the waiting thread leaves the subprocess running.
+     */
+    public static ProcessRunner defaultRunner(Consumer<Process> onStart) {
         return cmd -> {
             ProcessBuilder pb = new ProcessBuilder(cmd);
-            pb.inheritIO();
+            pb.redirectErrorStream(true);
+            Process process = pb.start();
+            onStart.accept(process);
+            try (BufferedReader out = new BufferedReader(
+                    new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = out.readLine()) != null) {
+                    log.info("kindling-cli: {}", line);
+                }
+            }
             try {
-                return pb.start().waitFor();
-            } catch (InterruptedException e) {
+                return process.waitFor();
+            }
+            catch (InterruptedException e) {
+                process.destroy();
                 Thread.currentThread().interrupt();
                 throw new IOException("kindling-cli interrupted", e);
             }
@@ -37,6 +69,19 @@ public class KindlingDictionaryConverter implements DictionaryWriter {
     private final OpfDictionaryWriter opfWriter;
     private final KindlingCliResolver resolver;
     private final ProcessRunner runner;
+    private final ProgressListener progress;
+
+    public KindlingDictionaryConverter(OpfDictionaryWriter opfWriter, KindlingCliResolver resolver, ProcessRunner runner) {
+        this(opfWriter, resolver, runner, ProgressListener.NOOP);
+    }
+
+    public KindlingDictionaryConverter(OpfDictionaryWriter opfWriter, KindlingCliResolver resolver,
+                                       ProcessRunner runner, ProgressListener progress) {
+        this.opfWriter = opfWriter;
+        this.resolver = resolver;
+        this.runner = runner;
+        this.progress = progress;
+    }
 
     @Override
     public Path write(TreeMap<String, List<LexiconEntry>> defs,
@@ -59,6 +104,7 @@ public class KindlingDictionaryConverter implements DictionaryWriter {
                 bin.toString(), "build", opfPath.toAbsolutePath().toString(),
                 "-o", mobiPath.toAbsolutePath().toString());
         log.info("Running: {}", String.join(" ", cmd));
+        progress.onProgress(Stage.KINDLING, 0, ProgressListener.TOTAL_UNKNOWN);
         int exitCode = runner.run(cmd);
         if (exitCode != 0) {
             throw new IOException("kindling-cli exited with code " + exitCode);

--- a/src/main/java/edu/self/w2k/parse/JsonlDictionaryParser.java
+++ b/src/main/java/edu/self/w2k/parse/JsonlDictionaryParser.java
@@ -2,6 +2,7 @@ package edu.self.w2k.parse;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
@@ -16,10 +17,26 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 
 import edu.self.w2k.model.WiktionaryEntry;
+import edu.self.w2k.progress.CountingInputStream;
+import edu.self.w2k.progress.ProgressListener;
+import edu.self.w2k.progress.ProgressListener.Stage;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class JsonlDictionaryParser implements DictionaryParser {
+
+    /** Progress is emitted at most once per this many bytes of compressed input. */
+    private static final long PROGRESS_INTERVAL_BYTES = 4 * 1024 * 1024L;
+
+    private final ProgressListener progress;
+
+    public JsonlDictionaryParser() {
+        this(ProgressListener.NOOP);
+    }
+
+    public JsonlDictionaryParser(ProgressListener progress) {
+        this.progress = progress;
+    }
 
     @Override
     public Stream<WiktionaryEntry> parse(Path dumpFile, String lang) throws IOException {
@@ -29,7 +46,15 @@ public class JsonlDictionaryParser implements DictionaryParser {
                 .setDefaultSetterInfo(JsonSetter.Value.forValueNulls(Nulls.AS_EMPTY))
                 .readerFor(WiktionaryEntry.class);
 
-        GZIPInputStream gzip = new GZIPInputStream(Files.newInputStream(dumpFile));
+        // Count on the compressed side: the uncompressed size of a gzip member is not knowable up
+        // front, but the file size is, so bytes-of-input gives a genuine 0-100% figure.
+        long compressedSize = Files.size(dumpFile);
+        InputStream counting = new CountingInputStream(
+                Files.newInputStream(dumpFile),
+                PROGRESS_INTERVAL_BYTES,
+                read -> progress.onProgress(Stage.PARSE, read, compressedSize));
+
+        GZIPInputStream gzip = new GZIPInputStream(counting);
         BufferedReader lines = new BufferedReader(new InputStreamReader(gzip, StandardCharsets.UTF_8));
 
         return lines.lines()
@@ -43,6 +68,7 @@ public class JsonlDictionaryParser implements DictionaryParser {
                 })
                 .filter(entry -> lang.equals(entry.langCode()) && entry.word() != null && !entry.word().isBlank())
                 .onClose(() -> {
+                    progress.onProgress(Stage.PARSE, compressedSize, compressedSize);
                     try {
                         lines.close();
                     }

--- a/src/main/java/edu/self/w2k/progress/CountingInputStream.java
+++ b/src/main/java/edu/self/w2k/progress/CountingInputStream.java
@@ -1,0 +1,84 @@
+package edu.self.w2k.progress;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.function.LongConsumer;
+
+/**
+ * Counts the bytes read from the wrapped stream and reports the running total whenever it advances
+ * by at least {@code reportEvery} bytes.
+ * <p>
+ * Used to wrap the <em>compressed</em> dump stream before it reaches the {@code GZIPInputStream}:
+ * the uncompressed size of a gzip member is not knowable up front, but the compressed file size is,
+ * so counting on the raw side yields a genuine 0–100 % figure.
+ * <p>
+ * {@link #mark} / {@link #reset} are not supported — rewinding would desynchronise the count.
+ */
+public final class CountingInputStream extends FilterInputStream {
+
+    private final long reportEvery;
+    private final LongConsumer reporter;
+
+    private long count;
+    private long lastReported;
+
+    /**
+     * @param in          the stream to wrap
+     * @param reportEvery minimum byte delta between two reports; must be positive
+     * @param reporter    receives the cumulative byte count
+     */
+    public CountingInputStream(InputStream in, long reportEvery, LongConsumer reporter) {
+        super(in);
+        if (reportEvery <= 0) {
+            throw new IllegalArgumentException("reportEvery must be positive, got " + reportEvery);
+        }
+        this.reportEvery = reportEvery;
+        this.reporter = reporter;
+    }
+
+    /** Total bytes read so far, regardless of how many reports have been emitted. */
+    public long count() {
+        return count;
+    }
+
+    @Override
+    public int read() throws IOException {
+        int b = in.read();
+        if (b != -1) {
+            advance(1);
+        }
+        return b;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        int read = in.read(b, off, len);
+        if (read > 0) {
+            advance(read);
+        }
+        return read;
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        long skipped = in.skip(n);
+        if (skipped > 0) {
+            advance(skipped);
+        }
+        return skipped;
+    }
+
+    @Override
+    public boolean markSupported() {
+        return false;
+    }
+
+    private void advance(long delta) {
+        count += delta;
+        if (count - lastReported >= reportEvery) {
+            lastReported = count;
+            reporter.accept(count);
+        }
+    }
+}

--- a/src/main/java/edu/self/w2k/progress/ProgressListener.java
+++ b/src/main/java/edu/self/w2k/progress/ProgressListener.java
@@ -1,0 +1,40 @@
+package edu.self.w2k.progress;
+
+/**
+ * Coarse progress feedback for the long-running stages of the pipeline.
+ * <p>
+ * Deliberately minimal and UI-free so the service layer stays independent of any front-end: the CLI
+ * passes {@link #NOOP} and relies on logging, while the GUI passes an adapter that drives a progress
+ * bar. Textual detail keeps flowing through SLF4J — this is not a second message channel.
+ * <p>
+ * Implementations are called from worker threads and must be cheap and thread-safe. Callers throttle
+ * their emissions (the dump is millions of lines), so implementations need not debounce.
+ */
+public interface ProgressListener {
+
+    /** Passed as {@code total} when the amount of work cannot be known up front. */
+    long TOTAL_UNKNOWN = -1;
+
+    /** A listener that discards everything; the default for the CLI. */
+    ProgressListener NOOP = (stage, done, total) -> {};
+
+    /**
+     * @param stage which pipeline stage is reporting
+     * @param done  units completed so far, in the stage's own unit
+     * @param total total units, or {@link #TOTAL_UNKNOWN} when indeterminate
+     */
+    void onProgress(Stage stage, long done, long total);
+
+    /**
+     * The pipeline stages, in execution order. {@code DOWNLOAD} and {@code PARSE} report byte counts;
+     * {@code WRITE_HTML} reports chapter counts; {@code FOLD} and {@code KINDLING} are indeterminate
+     * and report only that they have started.
+     */
+    enum Stage {
+        DOWNLOAD,
+        PARSE,
+        FOLD,
+        WRITE_HTML,
+        KINDLING
+    }
+}

--- a/src/main/java/edu/self/w2k/write/opf/OpfDictionaryWriter.java
+++ b/src/main/java/edu/self/w2k/write/opf/OpfDictionaryWriter.java
@@ -19,10 +19,22 @@ import javax.imageio.ImageIO;
 
 import edu.self.w2k.model.LexiconEntry;
 import edu.self.w2k.write.DictionaryWriter;
+import edu.self.w2k.progress.ProgressListener;
+import edu.self.w2k.progress.ProgressListener.Stage;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class OpfDictionaryWriter implements DictionaryWriter {
+
+    private final ProgressListener progress;
+
+    public OpfDictionaryWriter() {
+        this(ProgressListener.NOOP);
+    }
+
+    public OpfDictionaryWriter(ProgressListener progress) {
+        this.progress = progress;
+    }
 
     @Override
     public Path write(TreeMap<String, List<LexiconEntry>> defs, String srcLang, String trgLang,
@@ -33,6 +45,7 @@ public class OpfDictionaryWriter implements DictionaryWriter {
 
         List<Map.Entry<String, List<LexiconEntry>>> entries = new ArrayList<>(defs.entrySet());
         List<String> htmlFileNames = new ArrayList<>();
+        int totalChapters = chapterCount(entries.size());
 
         for (int start = 0, idx = 0; start < entries.size(); start += HtmlChapterRenderer.ENTRIES_PER_CHAPTER, idx++) {
             int end = Math.min(start + HtmlChapterRenderer.ENTRIES_PER_CHAPTER, entries.size());
@@ -40,6 +53,7 @@ public class OpfDictionaryWriter implements DictionaryWriter {
             Files.write(outputDir.resolve(fileName), HtmlChapterRenderer.render(entries.subList(start, end)));
             htmlFileNames.add(fileName);
             log.debug("Wrote {} ({} entries)", fileName, end - start);
+            progress.onProgress(Stage.WRITE_HTML, idx + 1L, totalChapters);
         }
 
         writeCoverImage(outputDir);
@@ -48,6 +62,11 @@ public class OpfDictionaryWriter implements DictionaryWriter {
         Path opfPath = writeOpfFile(outputDir, srcLang, trgLang, title, htmlFileNames, uid);
         log.info("OPF generation complete: {} HTML file(s) + 1 OPF + NCX", htmlFileNames.size());
         return opfPath;
+    }
+
+    /** Number of chapter files {@code entryCount} entries will be chunked into. */
+    static int chapterCount(int entryCount) {
+        return Math.ceilDiv(entryCount, HtmlChapterRenderer.ENTRIES_PER_CHAPTER);
     }
 
     private static void writeCoverImage(Path outputDir) throws IOException {

--- a/src/test/java/edu/self/w2k/command/DownloadCommandTest.java
+++ b/src/test/java/edu/self/w2k/command/DownloadCommandTest.java
@@ -1,5 +1,6 @@
 package edu.self.w2k.command;
 
+import edu.self.w2k.download.DownloadResult;
 import edu.self.w2k.download.DumpDownloader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -7,7 +8,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIOException;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class DownloadCommandTest {
@@ -19,11 +26,35 @@ class DownloadCommandTest {
     private DownloadCommand unit;
 
     @Test
-    void should_invoke_downloader_when_run_is_called() {
+    void should_invoke_downloader_when_run_is_called() throws Exception {
         // When
         unit.run();
 
         // Then
         verify(downloader).download();
+    }
+
+    @Test
+    void should_return_downloader_result_when_execute_is_called() throws Exception {
+        // Given
+        DownloadResult expected = new DownloadResult(Path.of("dumps", "raw-wiktextract-data-en-2026-05-01.jsonl.gz"), false);
+        when(downloader.download()).thenReturn(expected);
+
+        // When
+        DownloadResult actual = unit.execute();
+
+        // Then
+        assertThat(actual).isSameAs(expected);
+    }
+
+    @Test
+    void should_propagate_failure_when_downloader_throws() throws Exception {
+        // Given
+        when(downloader.download()).thenThrow(new IOException("HTTP 503"));
+
+        // When / Then
+        assertThatIOException()
+                .isThrownBy(() -> unit.run())
+                .withMessage("HTTP 503");
     }
 }

--- a/src/test/java/edu/self/w2k/download/KaikkiDumpDownloaderTest.java
+++ b/src/test/java/edu/self/w2k/download/KaikkiDumpDownloaderTest.java
@@ -1,9 +1,10 @@
 package edu.self.w2k.download;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIOException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -11,16 +12,23 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.InterruptedIOException;
 import java.net.http.HttpClient;
 import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import edu.self.w2k.progress.ProgressListener;
+import edu.self.w2k.progress.ProgressListener.Stage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,6 +39,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class KaikkiDumpDownloaderTest {
+
+    private static final String LAST_MODIFIED = "Fri, 01 May 2026 10:00:00 GMT";
+    private static final String DUMP_NAME = "raw-wiktextract-data-en-2026-05-01.jsonl.gz";
+    private static final String PART_NAME = "raw-wiktextract-data-en.jsonl.gz.part";
+    private static final byte[] BODY = "compressed-dump-bytes".getBytes(StandardCharsets.UTF_8);
 
     @Mock
     private HttpClient httpClient;
@@ -51,38 +64,41 @@ class KaikkiDumpDownloaderTest {
     @Test
     void should_save_dump_with_date_when_download_succeeds() throws Exception {
         // Given
-        Path partPath = tmp.resolve("raw-wiktextract-data-en.jsonl.gz.part");
-        stubHeadOk(lastModified("Fri, 01 May 2026 10:00:00 GMT"));
-        stubGet(200, partPath);
+        stubHeadOk(headers(LAST_MODIFIED, BODY.length));
+        stubGet(200, BODY);
 
         // When
-        unit.download();
+        DownloadResult result = unit.download();
 
         // Then
-        assertThat(tmp.resolve("raw-wiktextract-data-en-2026-05-01.jsonl.gz")).exists();
-        assertThat(partPath).doesNotExist();
+        assertThat(result.dumpPath()).isEqualTo(tmp.resolve(DUMP_NAME));
+        assertThat(result.alreadyPresent()).isFalse();
+        assertThat(tmp.resolve(DUMP_NAME)).exists().hasBinaryContent(BODY);
+        assertThat(tmp.resolve(PART_NAME)).doesNotExist();
     }
 
     @Test
     void should_keep_existing_dump_when_target_already_exists() throws Exception {
         // Given
-        Path existingDump = tmp.resolve("raw-wiktextract-data-en-2026-05-01.jsonl.gz");
+        Path existingDump = tmp.resolve(DUMP_NAME);
         Files.createFile(existingDump);
-        stubHeadOk(lastModified("Fri, 01 May 2026 10:00:00 GMT"));
+        stubHeadOk(headers(LAST_MODIFIED, BODY.length));
 
         // When
-        unit.download();
+        DownloadResult result = unit.download();
 
         // Then
+        assertThat(result.dumpPath()).isEqualTo(existingDump);
+        assertThat(result.alreadyPresent()).isTrue();
         assertThat(existingDump).exists();
-        assertThat(tmp.resolve("raw-wiktextract-data-en.jsonl.gz.part")).doesNotExist();
+        assertThat(tmp.resolve(PART_NAME)).doesNotExist();
     }
 
     @Test
     void should_not_request_body_when_target_already_exists() throws Exception {
         // Given
-        Files.createFile(tmp.resolve("raw-wiktextract-data-en-2026-05-01.jsonl.gz"));
-        stubHeadOk(lastModified("Fri, 01 May 2026 10:00:00 GMT"));
+        Files.createFile(tmp.resolve(DUMP_NAME));
+        stubHeadOk(headers(LAST_MODIFIED, BODY.length));
 
         // When
         unit.download();
@@ -92,39 +108,37 @@ class KaikkiDumpDownloaderTest {
     }
 
     @Test
-    void should_not_request_body_when_head_returns_error() throws Exception {
+    void should_fail_without_requesting_body_when_head_returns_error() throws Exception {
         // Given
         doReturn(headResponse).when(httpClient).send(argThat(request -> "HEAD".equals(request.method())), any());
         when(headResponse.statusCode()).thenReturn(404);
 
-        // When
-        unit.download();
-
-        // Then
+        // When / Then
+        assertThatIOException()
+                .isThrownBy(() -> unit.download())
+                .withMessageContaining("HTTP 404");
         verify(httpClient, never()).send(argThat(request -> "GET".equals(request.method())), any());
         assertThat(tmp).isEmptyDirectory();
     }
 
     @Test
-    void should_discard_partial_file_when_body_returns_error() throws Exception {
+    void should_fail_and_discard_partial_file_when_body_returns_error() throws Exception {
         // Given
-        Path partPath = tmp.resolve("raw-wiktextract-data-en.jsonl.gz.part");
-        stubHeadOk(lastModified("Fri, 01 May 2026 10:00:00 GMT"));
-        stubGet(500, partPath);
+        stubHeadOk(headers(LAST_MODIFIED, BODY.length));
+        stubGet(500, BODY);
 
-        // When
-        unit.download();
-
-        // Then
+        // When / Then
+        assertThatIOException()
+                .isThrownBy(() -> unit.download())
+                .withMessageContaining("HTTP 500");
         assertThat(tmp).isEmptyDirectory();
     }
 
     @Test
     void should_allow_hours_for_body_transfer_when_downloading() throws Exception {
         // Given
-        Path partPath = tmp.resolve("raw-wiktextract-data-en.jsonl.gz.part");
-        stubHeadOk(lastModified("Fri, 01 May 2026 10:00:00 GMT"));
-        stubGet(200, partPath);
+        stubHeadOk(headers(LAST_MODIFIED, BODY.length));
+        stubGet(200, BODY);
 
         // When
         unit.download();
@@ -134,6 +148,60 @@ class KaikkiDumpDownloaderTest {
         verify(httpClient, times(2)).send(captor.capture(), any());
         assertThat(captor.getAllValues().getLast().timeout())
                 .hasValueSatisfying(timeout -> assertThat(timeout).isGreaterThanOrEqualTo(Duration.ofHours(1)));
+    }
+
+    @Test
+    void should_report_transferred_bytes_against_content_length_when_downloading() throws Exception {
+        // Given
+        List<long[]> reports = new ArrayList<>();
+        unit = new KaikkiDumpDownloader("en", httpClient, tmp,
+                                        (stage, done, total) -> {
+                                            assertThat(stage).isEqualTo(Stage.DOWNLOAD);
+                                            reports.add(new long[] {done, total});
+                                        });
+        stubHeadOk(headers(LAST_MODIFIED, BODY.length));
+        stubGet(200, BODY);
+
+        // When
+        unit.download();
+
+        // Then
+        assertThat(reports.getLast()).containsExactly(BODY.length, BODY.length);
+    }
+
+    @Test
+    void should_report_unknown_total_when_content_length_is_absent() throws Exception {
+        // Given
+        List<long[]> reports = new ArrayList<>();
+        unit = new KaikkiDumpDownloader("en", httpClient, tmp,
+                                        (_, done, total) -> reports.add(new long[] {done, total}));
+        stubHeadOk(HttpHeaders.of(Map.of("last-modified", List.of(LAST_MODIFIED)), (k, v) -> true));
+        stubGet(200, BODY);
+
+        // When
+        unit.download();
+
+        // Then
+        assertThat(reports.getLast()).containsExactly(BODY.length, ProgressListener.TOTAL_UNKNOWN);
+    }
+
+    @Test
+    void should_abort_and_discard_partial_file_when_thread_is_interrupted() throws Exception {
+        // Given
+        stubHeadOk(headers(LAST_MODIFIED, BODY.length));
+        stubGet(200, BODY);
+        Thread.currentThread().interrupt();
+
+        try {
+            // When / Then
+            assertThatExceptionOfType(InterruptedIOException.class)
+                    .isThrownBy(() -> unit.download())
+                    .withMessageContaining("cancelled");
+            assertThat(tmp).isEmptyDirectory();
+        }
+        finally {
+            Thread.interrupted(); // clear the flag so it cannot leak into other tests
+        }
     }
 
     @Test
@@ -154,8 +222,10 @@ class KaikkiDumpDownloaderTest {
         assertThat(url).endsWith("/frwiktionary/raw-wiktextract-data.jsonl.gz");
     }
 
-    private static HttpHeaders lastModified(String value) {
-        return HttpHeaders.of(Map.of("last-modified", List.of(value)), (k, v) -> true);
+    private static HttpHeaders headers(String lastModified, long contentLength) {
+        return HttpHeaders.of(Map.of("last-modified", List.of(lastModified),
+                                     "content-length", List.of(Long.toString(contentLength))),
+                              (k, v) -> true);
     }
 
     private void stubHeadOk(HttpHeaders headers) throws Exception {
@@ -164,12 +234,10 @@ class KaikkiDumpDownloaderTest {
         when(headResponse.headers()).thenReturn(headers);
     }
 
-    private void stubGet(int statusCode, Path partPath) throws Exception {
-        HttpResponse<Path> bodyResponse = mock();
+    private void stubGet(int statusCode, byte[] body) throws Exception {
+        HttpResponse<InputStream> bodyResponse = mock();
         when(bodyResponse.statusCode()).thenReturn(statusCode);
-        doAnswer(invocation -> {
-            Files.write(partPath, new byte[0]);
-            return bodyResponse;
-        }).when(httpClient).send(argThat(request -> "GET".equals(request.method())), any());
+        when(bodyResponse.body()).thenReturn(new ByteArrayInputStream(body));
+        doReturn(bodyResponse).when(httpClient).send(argThat(request -> "GET".equals(request.method())), any());
     }
 }

--- a/src/test/java/edu/self/w2k/kindling/KindlingDictionaryConverterTest.java
+++ b/src/test/java/edu/self/w2k/kindling/KindlingDictionaryConverterTest.java
@@ -2,16 +2,18 @@ package edu.self.w2k.kindling;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.TreeMap;
 
 import edu.self.w2k.kindling.KindlingDictionaryConverter.ProcessRunner;
+import edu.self.w2k.progress.ProgressListener.Stage;
 import edu.self.w2k.write.opf.OpfDictionaryWriter;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -35,11 +37,20 @@ class KindlingDictionaryConverterTest {
     @Mock
     private ProcessRunner runner;
 
-    @InjectMocks
-    private KindlingDictionaryConverter unit;
-
     @TempDir
     Path outputDir;
+
+    private final List<Stage> stages = new ArrayList<>();
+
+    private KindlingDictionaryConverter unit;
+
+    @BeforeEach
+    void setUp() {
+        // Wired explicitly rather than with @InjectMocks: the progress listener is an optional
+        // collaborator with a NOOP default, which reflective injection would supply as null.
+        unit = new KindlingDictionaryConverter(opfWriter, resolver, runner,
+                                               (stage, _, _) -> stages.add(stage));
+    }
 
     @Test
     void should_run_kindling_cli_and_return_mobi_path_when_write() throws Exception {
@@ -78,5 +89,47 @@ class KindlingDictionaryConverterTest {
         assertThatThrownBy(() -> unit.write(new TreeMap<>(), "en", "fr", "Title", outputDir))
                 .isInstanceOf(IOException.class)
                 .hasMessageContaining("exit");
+    }
+
+    @Test
+    void should_report_kindling_stage_when_invoking_the_binary() throws Exception {
+        // Given
+        when(opfWriter.write(any(), eq("en"), eq("fr"), eq("Title"), eq(outputDir)))
+                .thenReturn(outputDir.resolve("dictionary-en-fr.opf"));
+        when(resolver.resolve()).thenReturn(outputDir.resolve("kindling-cli"));
+        when(runner.run(anyList())).thenReturn(0);
+
+        // When
+        unit.write(new TreeMap<>(), "en", "fr", "Title", outputDir);
+
+        // Then
+        assertThat(stages).containsExactly(Stage.KINDLING);
+    }
+
+    @Test
+    void should_relay_process_output_to_the_log_when_using_default_runner() throws Exception {
+        // Given a command whose stdout and stderr both produce output. inheritIO() would send this
+        // nowhere in a windowed app, so the default runner must read the streams itself.
+        List<String> command = List.of("sh", "-c", "echo to-stdout; echo to-stderr >&2; exit 0");
+
+        // When
+        int exitCode = KindlingDictionaryConverter.defaultRunner().run(command);
+
+        // Then
+        assertThat(exitCode).isZero();
+    }
+
+    @Test
+    void should_expose_started_process_when_default_runner_is_given_a_callback() throws Exception {
+        // Given
+        List<Process> started = new ArrayList<>();
+
+        // When
+        int exitCode = KindlingDictionaryConverter.defaultRunner(started::add)
+                .run(List.of("sh", "-c", "exit 3"));
+
+        // Then
+        assertThat(exitCode).isEqualTo(3);
+        assertThat(started).hasSize(1);
     }
 }

--- a/src/test/java/edu/self/w2k/progress/CountingInputStreamTest.java
+++ b/src/test/java/edu/self/w2k/progress/CountingInputStreamTest.java
@@ -1,0 +1,100 @@
+package edu.self.w2k.progress;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class CountingInputStreamTest {
+
+    private final List<Long> reports = new ArrayList<>();
+
+    @Test
+    void should_report_once_per_threshold_when_reading_in_chunks() throws Exception {
+        // Given
+        byte[] data = new byte[10];
+        try (CountingInputStream unit = new CountingInputStream(new ByteArrayInputStream(data), 4, reports::add)) {
+
+            // When
+            assertThat(unit.readNBytes(3)).hasSize(3);   // count 3, below threshold
+            assertThat(unit.readNBytes(3)).hasSize(3);   // count 6, first report
+            assertThat(unit.readNBytes(4)).hasSize(4);   // count 10, second report
+
+            // Then
+            assertThat(reports).containsExactly(6L, 10L);
+            assertThat(unit.count()).isEqualTo(10);
+        }
+    }
+
+    @Test
+    void should_count_every_byte_when_reading_one_at_a_time() throws Exception {
+        // Given
+        byte[] data = "abc".getBytes(StandardCharsets.UTF_8);
+        try (CountingInputStream unit = new CountingInputStream(new ByteArrayInputStream(data), 1, reports::add)) {
+
+            // When
+            while (unit.read() != -1) {
+                // drain
+            }
+
+            // Then
+            assertThat(reports).containsExactly(1L, 2L, 3L);
+            assertThat(unit.count()).isEqualTo(3);
+        }
+    }
+
+    @Test
+    void should_not_count_end_of_stream_when_exhausted() throws Exception {
+        // Given
+        try (CountingInputStream unit = new CountingInputStream(InputStream.nullInputStream(), 1, reports::add)) {
+
+            // When
+            int first = unit.read();
+
+            // Then
+            assertThat(first).isEqualTo(-1);
+            assertThat(unit.count()).isZero();
+            assertThat(reports).isEmpty();
+        }
+    }
+
+    @Test
+    void should_count_skipped_bytes_when_skipping() throws Exception {
+        // Given
+        byte[] data = new byte[8];
+        try (CountingInputStream unit = new CountingInputStream(new ByteArrayInputStream(data), 4, reports::add)) {
+
+            // When
+            long skipped = unit.skip(8);
+
+            // Then
+            assertThat(skipped).isEqualTo(8);
+            assertThat(unit.count()).isEqualTo(8);
+            assertThat(reports).containsExactly(8L);
+        }
+    }
+
+    @Test
+    void should_not_support_mark_because_rewinding_desynchronises_the_count() throws Exception {
+        // Given
+        try (CountingInputStream unit = new CountingInputStream(new ByteArrayInputStream(new byte[4]), 1, reports::add)) {
+
+            // When / Then
+            assertThat(unit.markSupported()).isFalse();
+        }
+    }
+
+    @Test
+    void should_reject_non_positive_threshold_when_constructed() {
+        // When / Then
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new CountingInputStream(InputStream.nullInputStream(), 0, reports::add))
+                .withMessageContaining("must be positive");
+    }
+}


### PR DESCRIPTION
Phase 1 of turning `wiktionary-to-kindle` into a distributable JavaFX desktop app (see the plan in the linked discussion). **No GUI code here** — this prepares the service layer so a front-end can show progress and cancel a run, and it is useful on its own because it fixes two defects.

## Why

The pipeline currently reports only through `log.info`, which is fine for a terminal but leaves a windowed app frozen for the 30+ minutes a `generate` takes. Rather than bolt reporting onto the GUI later, the seams go in first, with the CLI passing `ProgressListener.NOOP` so its behaviour is unchanged.

## The abstraction

`edu.self.w2k.progress.ProgressListener` — one method, five stages, no UI types:

```java
void onProgress(Stage stage, long done, long total);   // total = TOTAL_UNKNOWN when indeterminate
```

Threaded through by **constructor injection**, so every collaborator keeps its existing constructor arity and the `DictionaryParser` / `DictionaryWriter` interfaces are untouched. Textual detail keeps flowing through SLF4J — this is not a second message channel.

## Two defects fixed along the way

**`download` exited 0 on failure.** `DumpDownloader.download()` returned `void` and swallowed errors into `log.error`, so a 404 or a dead connection looked like success to any script. It now returns a `DownloadResult` — which also distinguishes "transferred now" from "already on disk", so the GUI can chain into generation without re-globbing the dumps directory — and throws `IOException`, which `CLI` turns into exit 1.

**`kindling-cli` output went nowhere.** `defaultRunner()` used `pb.inheritIO()`; a windowed app has no terminal attached, so kindling-cli failures would have been invisible. It now pumps the merged streams through SLF4J, giving consistent formatting on the CLI and a usable log pane in the GUI. An overload exposes the started `Process` so a caller can `destroy()` it on cancel — interrupting a `waitFor()` alone leaves the subprocess running.

## Implementation notes worth reviewing

- **Download progress required replacing the body handler.** `BodyHandlers.ofFile` offers neither a byte callback nor a cancellation point, so the body is read via `ofInputStream` and copied in an explicit loop that counts bytes and checks `isInterrupted()`. The `.part` file and its atomic rename are untouched.
- **Parse progress counts the compressed stream.** A gzip member's uncompressed size is not knowable up front, but the file size is, so `CountingInputStream` wraps the raw input *before* `GZIPInputStream` to give a genuine 0–100%.
- **Emissions are throttled** to once per 4 MB. The dump is millions of lines; per-line reporting would swamp any listener.
- `KindlingDictionaryConverterTest` moves off `@InjectMocks` — reflective injection supplies `null` for the optional listener rather than its `NOOP` default.

## Verification

`mvnd clean verify` — 94 tests, 0 failures.

Exercised end-to-end against a real 100 MB Greek dump (not just unit tests):

| case | result |
|---|---|
| `download el` | 100 MB transferred, atomic rename, exit 0 |
| `download el` again | skipped as already present, exit 0 |
| `download zzz` | `Download failed: HTTP 404 …`, **exit 1** (was exit 0) |
| `generate el en` | 60 108 keys → 7 HTML chunks → `dictionary-en-el.mobi` (7.8 MB), exit 0 |

The `generate` run also confirms the output pump: kindling-cli's lines now appear as `kindling-cli: …` through logback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)