### PR TITLE
feat(gui): add JavaFX desktop app over the existing pipeline

### DIFF
--- a/.github/workflows/java-ci.yaml
+++ b/.github/workflows/java-ci.yaml
@@ -28,7 +28,13 @@ jobs:
           distribution: temurin
           cache: maven
 
-      - run: mvn --no-transfer-progress verify
+      - name: Install Xvfb
+        run: sudo apt-get update && sudo apt-get install -y xvfb
+
+      # The GUI's FXML load test needs a graphics toolkit, and OpenJFX publishes no Monocle
+      # artifacts for this release line, so a virtual display is how it gets exercised here. The
+      # test self-skips if the toolkit cannot start, so this never hard-fails the build.
+      - run: xvfb-run -a mvn --no-transfer-progress verify
 
       - run: mvn --no-transfer-progress sonar:sonar
         if: env.SONAR_TOKEN != ''

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,23 @@
         <sonar.projectKey>nyg_wiktionary-to-kindle</sonar.projectKey>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+        <!--
+            Excluded from coverage measurement, not from analysis: these are JavaFX view and bootstrap
+            classes whose bodies are scene-graph construction and property binding. Reaching them
+            needs a running toolkit, and OpenJFX publishes no Monocle artifacts for this release line,
+            so they cannot be covered headlessly.
+
+            They are kept deliberately thin so little logic hides here — anything worth asserting
+            lives in MainViewModel, ProgressSnapshot, DictionaryPipeline, ByteSizes, LanguageConverter
+            and UiLogAppender, which are all covered. MainFxmlLoadTest additionally loads main.fxml
+            under Xvfb in CI and checks every @FXML field is injected.
+        -->
+        <sonar.coverage.exclusions>
+            src/main/java/edu/self/w2k/gui/App.java,
+            src/main/java/edu/self/w2k/gui/Launcher.java,
+            src/main/java/edu/self/w2k/gui/MainController.java,
+            src/main/java/edu/self/w2k/gui/PreferencesDialog.java
+        </sonar.coverage.exclusions>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,12 @@
         <!-- Third-party -->
         <commons-text.version>1.15.0</commons-text.version>
         <jackson-databind.version>2.22.0</jackson-databind.version>
+        <!--
+            Kept on the 25.x line to match maven.compiler.release and the JDK used in CI.
+            Maven resolves a platform-classified native artifact for the build host, which is why
+            org.openjfx is excluded from the shaded CLI JAR below.
+        -->
+        <javafx.version>25.0.4</javafx.version>
         <logback-classic.version>1.5.37</logback-classic.version>
         <lombok.version>1.18.46</lombok.version>
         <picocli.version>4.7.7</picocli.version>
@@ -28,6 +34,7 @@
         <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
         <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>5.1.0.4751</sonar-maven-plugin.version>
+        <javafx-maven-plugin.version>0.0.8</javafx-maven-plugin.version>
 
         <!-- SonarCloud -->
         <sonar.organization>nyg</sonar.organization>
@@ -58,16 +65,30 @@
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j-api.version}</version>
         </dependency>
+        <!--
+            Compile scope, not runtime: the GUI's UiLogAppender extends logback's AppenderBase to
+            feed the console pane, so the API is needed at compile time. Application code still logs
+            through the SLF4J facade only.
+        -->
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${logback-classic.version}</version>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
             <version>${picocli.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>${javafx.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-fxml</artifactId>
+            <version>${javafx.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -141,6 +162,18 @@
                 <version>${maven-shade-plugin.version}</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
+                    <!--
+                        The shaded JAR is the cross-platform CLI artifact. JavaFX resolves to a
+                        native, platform-classified artifact, so bundling it would silently tie this
+                        JAR to whichever OS built it. The CLI entry point never touches JavaFX, so
+                        excluding it here keeps one JAR usable everywhere; the GUI ships as a
+                        jpackage bundle with JavaFX in its runtime image instead.
+                    -->
+                    <artifactSet>
+                        <excludes>
+                            <exclude>org.openjfx:*</exclude>
+                        </excludes>
+                    </artifactSet>
                 </configuration>
                 <executions>
                     <execution>
@@ -150,6 +183,16 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+
+            <!-- Runs the GUI during development: mvn javafx:run -->
+            <plugin>
+                <groupId>org.openjfx</groupId>
+                <artifactId>javafx-maven-plugin</artifactId>
+                <version>${javafx-maven-plugin.version}</version>
+                <configuration>
+                    <mainClass>edu.self.w2k.gui.Launcher</mainClass>
+                </configuration>
             </plugin>
 
             <!-- Needed for code coverage analysis with SonarCloud. -->

--- a/src/main/java/edu/self/w2k/CLI.java
+++ b/src/main/java/edu/self/w2k/CLI.java
@@ -1,8 +1,6 @@
 package edu.self.w2k;
 
 import java.io.IOException;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.concurrent.Callable;

--- a/src/main/java/edu/self/w2k/command/GenerateCommand.java
+++ b/src/main/java/edu/self/w2k/command/GenerateCommand.java
@@ -61,6 +61,14 @@ public class GenerateCommand implements Command {
 
     @Override
     public void run() throws IOException {
+        execute();
+    }
+
+    /**
+     * Same work as {@link #run()}, but returns the generated dictionary. The GUI offers to reveal the
+     * result on disk, so it needs the path rather than reconstructing the writer's naming scheme.
+     */
+    public Path execute() throws IOException {
         log.info("Using dump: {}", dumpFile);
         TreeMap<String, List<LexiconEntry>> grouped = new TreeMap<>();
         AtomicLong count = new AtomicLong();
@@ -93,7 +101,7 @@ public class GenerateCommand implements Command {
         foldFormOfEntries(grouped);
         filterFormsCollidingWithHeadwords(grouped);
 
-        writer.write(grouped, srcLang, trgLang, title, outputDir);
+        return writer.write(grouped, srcLang, trgLang, title, outputDir);
     }
 
     /**

--- a/src/main/java/edu/self/w2k/gui/App.java
+++ b/src/main/java/edu/self/w2k/gui/App.java
@@ -1,0 +1,112 @@
+package edu.self.w2k.gui;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.core.FileAppender;
+import edu.self.w2k.config.AppPaths;
+import javafx.application.Application;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Scene;
+import javafx.scene.image.Image;
+import javafx.stage.Stage;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.LoggerFactory;
+
+@Slf4j
+public class App extends Application {
+
+    static final String MAIN_FXML = "/edu/self/w2k/gui/main.fxml";
+    static final String STYLESHEET = "/edu/self/w2k/gui/app.css";
+    static final String ICON = "/edu/self/w2k/gui/icon.png";
+
+    private static final String LOG_PATTERN = "%d{HH:mm:ss} %-5level - %msg%n";
+
+    private UiLogAppender uiAppender;
+
+    @Override
+    public void start(Stage stage) throws IOException {
+        uiAppender = installLogAppenders();
+
+        FXMLLoader loader = new FXMLLoader(App.class.getResource(MAIN_FXML));
+        loader.setControllerFactory(_ -> new MainController(uiAppender));
+        Scene scene = new Scene(loader.load());
+        scene.getStylesheets().add(App.class.getResource(STYLESHEET).toExternalForm());
+
+        stage.setTitle("Wiktionary to Kindle");
+        stage.setScene(scene);
+        stage.setMinWidth(720);
+        stage.setMinHeight(560);
+        loadIcon().ifPresent(stage.getIcons()::add);
+        stage.show();
+
+        // Logged after the appenders are installed, so both the console pane and the log file always
+        // open with the environment details a bug report needs.
+        log.info("wiktionary-to-kindle started — Java {}, {} {}, max heap {} MB",
+                 Runtime.version(),
+                 System.getProperty("os.name"),
+                 System.getProperty("os.arch"),
+                 Runtime.getRuntime().maxMemory() / (1024 * 1024));
+    }
+
+    @Override
+    public void stop() {
+        if (uiAppender != null) {
+            uiAppender.stop();
+        }
+    }
+
+    /**
+     * Attaches the GUI appenders programmatically rather than declaring them in {@code logback.xml},
+     * so the CLI's configuration is untouched and its console output stays exactly as it was.
+     */
+    private static UiLogAppender installLogAppenders() {
+        LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+        ch.qos.logback.classic.Logger root = context.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
+
+        UiLogAppender appender = new UiLogAppender();
+        appender.setContext(context);
+        appender.start();
+        root.addAppender(appender);
+
+        addFileAppender(context, root);
+        return appender;
+    }
+
+    /** A log file gives users something concrete to attach to a bug report. */
+    private static void addFileAppender(LoggerContext context, ch.qos.logback.classic.Logger root) {
+        try {
+            Path logFile = AppPaths.configDir().resolve("logs").resolve("app.log");
+            Files.createDirectories(logFile.getParent());
+
+            PatternLayoutEncoder encoder = new PatternLayoutEncoder();
+            encoder.setContext(context);
+            encoder.setPattern(LOG_PATTERN);
+            encoder.start();
+
+            FileAppender<ch.qos.logback.classic.spi.ILoggingEvent> fileAppender = new FileAppender<>();
+            fileAppender.setContext(context);
+            fileAppender.setName("file");
+            fileAppender.setFile(logFile.toString());
+            fileAppender.setAppend(false);
+            fileAppender.setEncoder(encoder);
+            fileAppender.start();
+
+            root.addAppender(fileAppender);
+            root.setLevel(Level.INFO);
+        }
+        catch (IOException e) {
+            // Not fatal: the console pane still works, so the app must not refuse to start.
+            root.warn("Could not open log file: {}", e.getLocalizedMessage());
+        }
+    }
+
+    private java.util.Optional<Image> loadIcon() {
+        var stream = App.class.getResourceAsStream(ICON);
+        return stream == null ? java.util.Optional.empty() : java.util.Optional.of(new Image(stream));
+    }
+}

--- a/src/main/java/edu/self/w2k/gui/ByteSizes.java
+++ b/src/main/java/edu/self/w2k/gui/ByteSizes.java
@@ -1,0 +1,25 @@
+package edu.self.w2k.gui;
+
+/** Human-readable byte counts for the dumps table. */
+public final class ByteSizes {
+
+    private static final long KB = 1024L;
+    private static final long MB = 1024L * KB;
+    private static final long GB = 1024L * MB;
+
+    private ByteSizes() {}
+
+    /** Formats {@code bytes}, or {@code "?"} for the negative value used when the size is unknown. */
+    public static String format(long bytes) {
+        if (bytes < 0) {
+            return "?";
+        }
+        if (bytes < MB) {
+            return "%d KB".formatted(bytes / KB);
+        }
+        if (bytes < GB) {
+            return "%d MB".formatted(bytes / MB);
+        }
+        return "%.1f GB".formatted((double) bytes / GB);
+    }
+}

--- a/src/main/java/edu/self/w2k/gui/LanguageConverter.java
+++ b/src/main/java/edu/self/w2k/gui/LanguageConverter.java
@@ -1,0 +1,32 @@
+package edu.self.w2k.gui;
+
+import edu.self.w2k.config.LanguageCatalog.Language;
+import javafx.util.StringConverter;
+
+/**
+ * Renders a language as {@code "Name (code)"} and parses either that form or a bare code back.
+ * <p>
+ * The bare-code path is what makes the edition combo usefully editable: kaikki.org adds editions
+ * between releases, so a code absent from the bundled list can still be typed in directly.
+ */
+public class LanguageConverter extends StringConverter<Language> {
+
+    @Override
+    public String toString(Language language) {
+        return language == null ? "" : language.toString();
+    }
+
+    @Override
+    public Language fromString(String text) {
+        if (text == null || text.isBlank()) {
+            return null;
+        }
+        String trimmed = text.strip();
+        int open = trimmed.lastIndexOf('(');
+        int close = trimmed.lastIndexOf(')');
+        String code = open >= 0 && close > open
+                ? trimmed.substring(open + 1, close).strip()
+                : trimmed;
+        return code.isEmpty() ? null : Language.of(code);
+    }
+}

--- a/src/main/java/edu/self/w2k/gui/Launcher.java
+++ b/src/main/java/edu/self/w2k/gui/Launcher.java
@@ -1,0 +1,23 @@
+package edu.self.w2k.gui;
+
+import javafx.application.Application;
+
+/**
+ * Entry point for the desktop app.
+ * <p>
+ * Exists solely so the main class is <em>not</em> the {@link Application} subclass. When the app runs
+ * from the classpath rather than as a JPMS module — which it must, since Jackson, logback and picocli
+ * are not modules — the JavaFX launcher rejects a main class that extends {@code Application} with
+ * "JavaFX runtime components are missing". Delegating from a plain class sidesteps that check.
+ * <p>
+ * This is the class jpackage is pointed at; the shaded CLI JAR keeps {@code edu.self.w2k.CLI} as its
+ * manifest main class.
+ */
+public final class Launcher {
+
+    private Launcher() {}
+
+    public static void main(String[] args) {
+        Application.launch(App.class, args);
+    }
+}

--- a/src/main/java/edu/self/w2k/gui/MainController.java
+++ b/src/main/java/edu/self/w2k/gui/MainController.java
@@ -1,0 +1,253 @@
+package edu.self.w2k.gui;
+
+import java.awt.Desktop;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.self.w2k.config.LanguageCatalog;
+import edu.self.w2k.config.LanguageCatalog.Language;
+import edu.self.w2k.config.Preferences;
+import edu.self.w2k.dump.DumpCatalog;
+import edu.self.w2k.dump.DumpFile;
+import javafx.animation.Animation;
+import javafx.animation.KeyFrame;
+import javafx.animation.Timeline;
+import javafx.application.Platform;
+import javafx.beans.binding.Bindings;
+import javafx.collections.FXCollections;
+import javafx.fxml.FXML;
+import javafx.scene.control.Alert;
+import javafx.scene.control.Button;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
+import javafx.scene.control.ListView;
+import javafx.scene.control.ProgressBar;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
+import javafx.scene.control.cell.PropertyValueFactory;
+import javafx.util.Duration;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Wires the main window to {@link MainViewModel}. Kept deliberately thin — anything worth testing
+ * belongs in the view model, which needs no toolkit.
+ */
+@Slf4j
+public class MainController {
+
+    /**
+     * How often the console pane pulls buffered log lines. 10 Hz is fast enough to look live and slow
+     * enough that a burst of thousands of lines becomes a handful of batched list updates.
+     */
+    private static final Duration LOG_DRAIN_INTERVAL = Duration.millis(100);
+
+    private static final int MAX_LINES_PER_DRAIN = 500;
+
+    @FXML private ComboBox<Language> editionCombo;
+    @FXML private ComboBox<Language> wordLanguageCombo;
+    @FXML private Label titlePreview;
+    @FXML private Button startButton;
+    @FXML private Button cancelButton;
+    @FXML private ProgressBar progressBar;
+    @FXML private Label statusLabel;
+    @FXML private ListView<String> logView;
+    @FXML private Button revealButton;
+
+    @FXML private TableView<DumpFile> dumpsTable;
+    @FXML private TableColumn<DumpFile, String> dumpLangColumn;
+    @FXML private TableColumn<DumpFile, Object> dumpDateColumn;
+    @FXML private TableColumn<DumpFile, String> dumpSizeColumn;
+    @FXML private Button deleteDumpButton;
+    @FXML private Label dumpsLocationLabel;
+
+    private final UiLogAppender logAppender;
+    private final MainViewModel viewModel = new MainViewModel();
+
+    private PipelineService pipeline;
+    private Timeline logDrain;
+
+    public MainController(UiLogAppender logAppender) {
+        this.logAppender = logAppender;
+    }
+
+    @FXML
+    void initialize() {
+        viewModel.preferencesProperty().set(Preferences.load());
+
+        setUpLanguagePickers();
+        setUpProgressBindings();
+        setUpLogConsole();
+        setUpDumpsTable();
+
+        pipeline = new PipelineService(viewModel, this::onProgress);
+        viewModel.runningProperty().bind(pipeline.runningProperty());
+        pipeline.setOnSucceeded(_ -> onFinished(pipeline.getValue()));
+        pipeline.setOnFailed(_ -> onFailed(pipeline.getException()));
+        pipeline.setOnCancelled(_ -> viewModel.report(new ProgressSnapshot(0, "Cancelled")));
+
+        startButton.disableProperty().bind(viewModel.startableProperty().not());
+        cancelButton.disableProperty().bind(viewModel.runningProperty().not());
+        revealButton.disableProperty().bind(viewModel.lastOutputProperty().isNull());
+
+        refreshDumps();
+    }
+
+    private void setUpLanguagePickers() {
+        editionCombo.setItems(FXCollections.observableArrayList(LanguageCatalog.editions()));
+        wordLanguageCombo.setItems(FXCollections.observableArrayList(LanguageCatalog.wordLanguages()));
+
+        // Editable so an edition kaikki added since this build can still be entered by hand.
+        editionCombo.setEditable(true);
+        editionCombo.setConverter(new LanguageConverter());
+        wordLanguageCombo.setConverter(new LanguageConverter());
+
+        viewModel.editionProperty().bind(editionCombo.valueProperty());
+        viewModel.wordLanguageProperty().bind(wordLanguageCombo.valueProperty());
+        titlePreview.textProperty().bind(viewModel.titleProperty());
+    }
+
+    private void setUpProgressBindings() {
+        progressBar.progressProperty().bind(Bindings.createDoubleBinding(
+                () -> viewModel.progressProperty().get().fraction(), viewModel.progressProperty()));
+        statusLabel.textProperty().bind(Bindings.createStringBinding(
+                () -> viewModel.progressProperty().get().message(), viewModel.progressProperty()));
+    }
+
+    private void setUpLogConsole() {
+        logView.setItems(viewModel.getLogLines());
+        // A single timer draining in batches, rather than one runLater per log event.
+        logDrain = new Timeline(new KeyFrame(LOG_DRAIN_INTERVAL, _ -> drainLog()));
+        logDrain.setCycleCount(Animation.INDEFINITE);
+        logDrain.play();
+    }
+
+    private void drainLog() {
+        List<String> batch = new ArrayList<>();
+        if (logAppender.drainTo(batch, MAX_LINES_PER_DRAIN) > 0) {
+            viewModel.appendLog(batch);
+            logView.scrollTo(viewModel.getLogLines().size() - 1);
+        }
+    }
+
+    private void setUpDumpsTable() {
+        dumpLangColumn.setCellValueFactory(new PropertyValueFactory<>("lang"));
+        dumpDateColumn.setCellValueFactory(new PropertyValueFactory<>("generated"));
+        dumpSizeColumn.setCellValueFactory(cell ->
+                Bindings.createStringBinding(() -> ByteSizes.format(cell.getValue().sizeBytes())));
+        dumpsTable.setItems(viewModel.getDumps());
+        deleteDumpButton.disableProperty()
+                .bind(dumpsTable.getSelectionModel().selectedItemProperty().isNull());
+        dumpsLocationLabel.setText(viewModel.preferencesProperty().get().dumpsDir().toString());
+    }
+
+    /** Called from the worker thread; hops to the FX thread before touching the view model. */
+    private void onProgress(edu.self.w2k.progress.ProgressListener.Stage stage, long done, long total) {
+        ProgressSnapshot snapshot = ProgressSnapshot.of(stage, done, total);
+        Platform.runLater(() -> viewModel.report(snapshot));
+    }
+
+    @FXML
+    void onStart() {
+        viewModel.lastOutputProperty().set(null);
+        viewModel.clearLog();
+        pipeline.reset();
+        pipeline.start();
+    }
+
+    @FXML
+    void onCancel() {
+        pipeline.cancel();
+    }
+
+    @FXML
+    void onReveal() {
+        Path output = viewModel.lastOutputProperty().get();
+        if (output == null) {
+            return;
+        }
+        // Runs off the FX thread: Desktop calls can block on the platform file manager.
+        Thread.ofVirtual().start(() -> {
+            try {
+                Desktop.getDesktop().open(output.getParent().toFile());
+            }
+            catch (IOException | UnsupportedOperationException e) {
+                log.warn("Could not open {}: {}", output.getParent(), e.getLocalizedMessage());
+            }
+        });
+    }
+
+    @FXML
+    void onRefreshDumps() {
+        refreshDumps();
+    }
+
+    @FXML
+    void onDeleteDump() {
+        DumpFile selected = dumpsTable.getSelectionModel().getSelectedItem();
+        if (selected == null) {
+            return;
+        }
+
+        Alert confirm = new Alert(Alert.AlertType.CONFIRMATION,
+                                  "Delete %s (%s)?".formatted(selected.path().getFileName(),
+                                                              ByteSizes.format(selected.sizeBytes())));
+        confirm.setHeaderText("Delete dump");
+        confirm.showAndWait()
+                .filter(button -> button == javafx.scene.control.ButtonType.OK)
+                .ifPresent(_ -> deleteDump(selected));
+    }
+
+    private void deleteDump(DumpFile dump) {
+        try {
+            catalog().delete(dump);
+            refreshDumps();
+        }
+        catch (IOException e) {
+            log.error("Could not delete {}: {}", dump.path(), e.getLocalizedMessage());
+            new Alert(Alert.AlertType.ERROR, "Could not delete the dump: " + e.getLocalizedMessage())
+                    .showAndWait();
+        }
+    }
+
+    private void refreshDumps() {
+        viewModel.getDumps().setAll(catalog().list());
+    }
+
+    private DumpCatalog catalog() {
+        return new DumpCatalog(viewModel.preferencesProperty().get().dumpsDir());
+    }
+
+    @FXML
+    void onPreferences() {
+        new PreferencesDialog(viewModel.preferencesProperty().get())
+                .showAndWait()
+                .ifPresent(updated -> {
+                    viewModel.preferencesProperty().set(updated);
+                    dumpsLocationLabel.setText(updated.dumpsDir().toString());
+                    refreshDumps();
+                    try {
+                        updated.store();
+                    }
+                    catch (IOException e) {
+                        log.error("Could not save preferences: {}", e.getLocalizedMessage());
+                    }
+                });
+    }
+
+    private void onFinished(Path mobi) {
+        viewModel.lastOutputProperty().set(mobi);
+        viewModel.report(new ProgressSnapshot(1, "Done — " + mobi.getFileName()));
+        refreshDumps();
+        if (logAppender.droppedCount() > 0) {
+            log.warn("{} log lines were dropped; see the log file for the full record",
+                     logAppender.droppedCount());
+        }
+    }
+
+    private void onFailed(Throwable error) {
+        log.error("Pipeline failed", error);
+        viewModel.report(new ProgressSnapshot(0, "Failed — " + error.getLocalizedMessage()));
+    }
+}

--- a/src/main/java/edu/self/w2k/gui/MainViewModel.java
+++ b/src/main/java/edu/self/w2k/gui/MainViewModel.java
@@ -1,0 +1,128 @@
+package edu.self.w2k.gui;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import edu.self.w2k.config.LanguageCatalog.Language;
+import edu.self.w2k.config.Preferences;
+import edu.self.w2k.dump.DumpFile;
+import edu.self.w2k.write.DictionaryTitles;
+import javafx.beans.binding.Bindings;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.ReadOnlyBooleanProperty;
+import javafx.beans.property.ReadOnlyStringProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+
+/**
+ * Observable state behind the main window.
+ * <p>
+ * All the logic lives here rather than in the FXML controller, which keeps it testable: JavaFX
+ * properties and bindings work without an initialised toolkit, so this class can be exercised in a
+ * plain unit test while a controller could not.
+ */
+public class MainViewModel {
+
+    /**
+     * Console lines retained. A full run logs far more than this; the pane is for watching progress
+     * and diagnosing the tail of a failure, and an unbounded list would grow without limit across a
+     * long session. The complete record goes to the log file.
+     */
+    static final int MAX_LOG_LINES = 5_000;
+
+    private final ObjectProperty<Language> edition = new SimpleObjectProperty<>();
+    private final ObjectProperty<Language> wordLanguage = new SimpleObjectProperty<>();
+    private final StringProperty title = new SimpleStringProperty("");
+    private final ObjectProperty<ProgressSnapshot> progress =
+            new SimpleObjectProperty<>(ProgressSnapshot.idle());
+    private final BooleanProperty running = new SimpleBooleanProperty(false);
+    private final ObjectProperty<Path> lastOutput = new SimpleObjectProperty<>();
+    private final ObjectProperty<Preferences> preferences =
+            new SimpleObjectProperty<>(Preferences.defaults());
+
+    private final ObservableList<String> logLines = FXCollections.observableArrayList();
+    private final ObservableList<DumpFile> dumps = FXCollections.observableArrayList();
+
+    private final BooleanProperty startable = new SimpleBooleanProperty(false);
+
+    public MainViewModel() {
+        title.bind(Bindings.createStringBinding(this::computeTitle, edition, wordLanguage));
+        startable.bind(edition.isNotNull().and(wordLanguage.isNotNull()).and(running.not()));
+    }
+
+    private String computeTitle() {
+        Language src = wordLanguage.get();
+        Language trg = edition.get();
+        if (src == null || trg == null) {
+            return "";
+        }
+        // Argument order matches the CLI: the word language is the source, the edition the target.
+        return DictionaryTitles.autoTitle(src.code(), trg.code());
+    }
+
+    /** Applies a listener callback, replacing the current progress display. */
+    public void report(ProgressSnapshot snapshot) {
+        progress.set(snapshot);
+    }
+
+    /** Appends console lines, trimming the oldest beyond {@link #MAX_LOG_LINES}. */
+    public void appendLog(List<String> lines) {
+        if (lines.isEmpty()) {
+            return;
+        }
+        logLines.addAll(lines);
+        int excess = logLines.size() - MAX_LOG_LINES;
+        if (excess > 0) {
+            logLines.remove(0, excess);
+        }
+    }
+
+    public void clearLog() {
+        logLines.clear();
+    }
+
+    public ObjectProperty<Language> editionProperty() {
+        return edition;
+    }
+
+    public ObjectProperty<Language> wordLanguageProperty() {
+        return wordLanguage;
+    }
+
+    public ReadOnlyStringProperty titleProperty() {
+        return title;
+    }
+
+    public ObjectProperty<ProgressSnapshot> progressProperty() {
+        return progress;
+    }
+
+    public BooleanProperty runningProperty() {
+        return running;
+    }
+
+    public ReadOnlyBooleanProperty startableProperty() {
+        return startable;
+    }
+
+    public ObjectProperty<Path> lastOutputProperty() {
+        return lastOutput;
+    }
+
+    public ObjectProperty<Preferences> preferencesProperty() {
+        return preferences;
+    }
+
+    public ObservableList<String> getLogLines() {
+        return logLines;
+    }
+
+    public ObservableList<DumpFile> getDumps() {
+        return dumps;
+    }
+}

--- a/src/main/java/edu/self/w2k/gui/PipelineService.java
+++ b/src/main/java/edu/self/w2k/gui/PipelineService.java
@@ -4,62 +4,61 @@ import java.nio.file.Path;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
-import edu.self.w2k.command.GenerateCommand;
 import edu.self.w2k.config.Preferences;
-import edu.self.w2k.download.DownloadResult;
-import edu.self.w2k.download.KaikkiDumpDownloader;
-import edu.self.w2k.kindling.KindlingCliResolver;
-import edu.self.w2k.kindling.KindlingDictionaryConverter;
-import edu.self.w2k.kindling.KindlingDownloader;
-import edu.self.w2k.kindling.KindlingRelease;
-import edu.self.w2k.parse.JsonlDictionaryParser;
+import edu.self.w2k.pipeline.DictionaryPipeline;
 import edu.self.w2k.progress.ProgressListener;
-import edu.self.w2k.render.HtmlDefinitionRenderer;
-import edu.self.w2k.write.DictionaryTitles;
-import edu.self.w2k.write.opf.OpfDictionaryWriter;
 import javafx.concurrent.Service;
 import javafx.concurrent.Task;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Runs the whole download-then-generate pipeline on a background thread, so the one-click flow is a
- * single cancellable unit of work.
+ * Runs {@link DictionaryPipeline} on a background thread so the one-click flow is a single
+ * cancellable unit of work. The orchestration itself lives in the pipeline class, which keeps it
+ * testable without a UI; this adds only threading and cancellation.
  * <p>
  * Cancellation needs two mechanisms, not one. {@code cancel(true)} interrupts the worker, which the
- * download and parse loops check; but the kindling-cli stage is blocked in {@code Process.waitFor()},
- * where interrupting the waiting thread would leave the subprocess running and the MOBI half-written.
- * The process reference is therefore tracked and destroyed in {@link Task#cancelled()}.
+ * download and parse loops check; but the kindling-cli stage blocks in {@code Process.waitFor()},
+ * where interrupting the waiting thread would leave the subprocess running and the MOBI
+ * half-written. The process reference is therefore tracked and destroyed in {@link Task#cancelled()}.
  */
 @Slf4j
 public class PipelineService extends Service<Path> {
 
     private final MainViewModel viewModel;
     private final ProgressListener progress;
+    private final DictionaryPipeline pipeline;
 
     public PipelineService(MainViewModel viewModel, ProgressListener progress) {
+        this(viewModel, progress, new DictionaryPipeline());
+    }
+
+    PipelineService(MainViewModel viewModel, ProgressListener progress, DictionaryPipeline pipeline) {
         this.viewModel = viewModel;
         this.progress = progress;
+        this.pipeline = pipeline;
     }
 
     @Override
     protected Task<Path> createTask() {
-        Preferences prefs = viewModel.preferencesProperty().get();
-        String editionLang = viewModel.editionProperty().get().code();
-        String wordLang = viewModel.wordLanguageProperty().get().code();
-
-        return new PipelineTask(prefs, editionLang, wordLang, progress);
+        return new PipelineTask(pipeline,
+                                viewModel.preferencesProperty().get(),
+                                viewModel.editionProperty().get().code(),
+                                viewModel.wordLanguageProperty().get().code(),
+                                progress);
     }
 
-    /** Package-private so the pipeline can be exercised without an FX toolkit. */
     static class PipelineTask extends Task<Path> {
 
+        private final DictionaryPipeline pipeline;
         private final Preferences prefs;
         private final String editionLang;
         private final String wordLang;
         private final ProgressListener progress;
         private final AtomicReference<Process> kindlingProcess = new AtomicReference<>();
 
-        PipelineTask(Preferences prefs, String editionLang, String wordLang, ProgressListener progress) {
+        PipelineTask(DictionaryPipeline pipeline, Preferences prefs, String editionLang,
+                     String wordLang, ProgressListener progress) {
+            this.pipeline = pipeline;
             this.prefs = prefs;
             this.editionLang = editionLang;
             this.wordLang = wordLang;
@@ -68,38 +67,17 @@ public class PipelineService extends Service<Path> {
 
         @Override
         protected Path call() throws Exception {
-            DownloadResult download =
-                    new KaikkiDumpDownloader(editionLang, prefs.dumpsDir(), progress).download();
-            if (download.alreadyPresent()) {
-                log.info("Using already-downloaded dump: {}", download.dumpPath());
-            }
-
-            String version = prefs.kindlingVersion().orElseGet(() -> KindlingRelease.load().version());
-            KindlingCliResolver resolver =
-                    new KindlingCliResolver(version, prefs.kindlingCliPath(), new KindlingDownloader());
-
-            KindlingDictionaryConverter writer = new KindlingDictionaryConverter(
-                    new OpfDictionaryWriter(progress),
-                    resolver,
-                    KindlingDictionaryConverter.defaultRunner(kindlingProcess::set),
-                    progress);
-
-            return new GenerateCommand(
-                    new JsonlDictionaryParser(progress),
-                    new HtmlDefinitionRenderer(),
-                    writer,
-                    download.dumpPath(),
-                    prefs.dictionariesDir(),
-                    wordLang,
-                    editionLang,
-                    DictionaryTitles.autoTitle(wordLang, editionLang),
-                    progress
-            ).execute();
+            return pipeline.run(prefs, editionLang, wordLang, progress, kindlingProcess::set);
         }
 
         @Override
         protected void cancelled() {
             super.cancelled();
+            terminateKindling();
+        }
+
+        /** Package-private so cancellation can be verified without driving a real Service. */
+        void terminateKindling() {
             Optional.ofNullable(kindlingProcess.get())
                     .filter(Process::isAlive)
                     .ifPresent(process -> {

--- a/src/main/java/edu/self/w2k/gui/PipelineService.java
+++ b/src/main/java/edu/self/w2k/gui/PipelineService.java
@@ -1,0 +1,111 @@
+package edu.self.w2k.gui;
+
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import edu.self.w2k.command.GenerateCommand;
+import edu.self.w2k.config.Preferences;
+import edu.self.w2k.download.DownloadResult;
+import edu.self.w2k.download.KaikkiDumpDownloader;
+import edu.self.w2k.kindling.KindlingCliResolver;
+import edu.self.w2k.kindling.KindlingDictionaryConverter;
+import edu.self.w2k.kindling.KindlingDownloader;
+import edu.self.w2k.kindling.KindlingRelease;
+import edu.self.w2k.parse.JsonlDictionaryParser;
+import edu.self.w2k.progress.ProgressListener;
+import edu.self.w2k.render.HtmlDefinitionRenderer;
+import edu.self.w2k.write.DictionaryTitles;
+import edu.self.w2k.write.opf.OpfDictionaryWriter;
+import javafx.concurrent.Service;
+import javafx.concurrent.Task;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Runs the whole download-then-generate pipeline on a background thread, so the one-click flow is a
+ * single cancellable unit of work.
+ * <p>
+ * Cancellation needs two mechanisms, not one. {@code cancel(true)} interrupts the worker, which the
+ * download and parse loops check; but the kindling-cli stage is blocked in {@code Process.waitFor()},
+ * where interrupting the waiting thread would leave the subprocess running and the MOBI half-written.
+ * The process reference is therefore tracked and destroyed in {@link Task#cancelled()}.
+ */
+@Slf4j
+public class PipelineService extends Service<Path> {
+
+    private final MainViewModel viewModel;
+    private final ProgressListener progress;
+
+    public PipelineService(MainViewModel viewModel, ProgressListener progress) {
+        this.viewModel = viewModel;
+        this.progress = progress;
+    }
+
+    @Override
+    protected Task<Path> createTask() {
+        Preferences prefs = viewModel.preferencesProperty().get();
+        String editionLang = viewModel.editionProperty().get().code();
+        String wordLang = viewModel.wordLanguageProperty().get().code();
+
+        return new PipelineTask(prefs, editionLang, wordLang, progress);
+    }
+
+    /** Package-private so the pipeline can be exercised without an FX toolkit. */
+    static class PipelineTask extends Task<Path> {
+
+        private final Preferences prefs;
+        private final String editionLang;
+        private final String wordLang;
+        private final ProgressListener progress;
+        private final AtomicReference<Process> kindlingProcess = new AtomicReference<>();
+
+        PipelineTask(Preferences prefs, String editionLang, String wordLang, ProgressListener progress) {
+            this.prefs = prefs;
+            this.editionLang = editionLang;
+            this.wordLang = wordLang;
+            this.progress = progress;
+        }
+
+        @Override
+        protected Path call() throws Exception {
+            DownloadResult download =
+                    new KaikkiDumpDownloader(editionLang, prefs.dumpsDir(), progress).download();
+            if (download.alreadyPresent()) {
+                log.info("Using already-downloaded dump: {}", download.dumpPath());
+            }
+
+            String version = prefs.kindlingVersion().orElseGet(() -> KindlingRelease.load().version());
+            KindlingCliResolver resolver =
+                    new KindlingCliResolver(version, prefs.kindlingCliPath(), new KindlingDownloader());
+
+            KindlingDictionaryConverter writer = new KindlingDictionaryConverter(
+                    new OpfDictionaryWriter(progress),
+                    resolver,
+                    KindlingDictionaryConverter.defaultRunner(kindlingProcess::set),
+                    progress);
+
+            return new GenerateCommand(
+                    new JsonlDictionaryParser(progress),
+                    new HtmlDefinitionRenderer(),
+                    writer,
+                    download.dumpPath(),
+                    prefs.dictionariesDir(),
+                    wordLang,
+                    editionLang,
+                    DictionaryTitles.autoTitle(wordLang, editionLang),
+                    progress
+            ).execute();
+        }
+
+        @Override
+        protected void cancelled() {
+            super.cancelled();
+            Optional.ofNullable(kindlingProcess.get())
+                    .filter(Process::isAlive)
+                    .ifPresent(process -> {
+                        log.warn("Cancelled — terminating kindling-cli");
+                        process.destroy();
+                    });
+        }
+    }
+}

--- a/src/main/java/edu/self/w2k/gui/PreferencesDialog.java
+++ b/src/main/java/edu/self/w2k/gui/PreferencesDialog.java
@@ -1,0 +1,151 @@
+package edu.self.w2k.gui;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import edu.self.w2k.config.Preferences;
+import edu.self.w2k.kindling.KindlingRelease;
+import javafx.geometry.Insets;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.Dialog;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.stage.DirectoryChooser;
+import javafx.stage.FileChooser;
+
+/**
+ * Modal preferences editor, returning the edited {@link Preferences} on OK.
+ * <p>
+ * Built in code rather than FXML: it is a four-row form, and a second FXML file plus controller would
+ * add wiring to get wrong without making the form any clearer.
+ * <p>
+ * Max heap is shown read-only. It cannot be a setting — the heap is fixed when the JVM starts, so a
+ * value changed here could not take effect, and rewriting jpackage's {@code .cfg} to persist one
+ * would invalidate the macOS ad-hoc signature. The bundle ships {@code -XX:MaxRAMPercentage=75}
+ * instead, which scales with the machine.
+ */
+public class PreferencesDialog extends Dialog<Preferences> {
+
+    /** Below this, the largest editions are at real risk of exhausting the heap. */
+    static final long LOW_HEAP_THRESHOLD_MB = 4096;
+
+    private static final long BYTES_PER_MB = 1024L * 1024L;
+
+    private final TextField dumpsDir = new TextField();
+    private final TextField dictionariesDir = new TextField();
+    private final TextField kindlingCliPath = new TextField();
+    private final TextField kindlingVersion = new TextField();
+
+    public PreferencesDialog(Preferences current) {
+        setTitle("Preferences");
+        setHeaderText("Where files are kept, and which kindling-cli to use");
+        getDialogPane().getButtonTypes().addAll(ButtonType.OK, ButtonType.CANCEL);
+
+        dumpsDir.setText(current.dumpsDir().toString());
+        dictionariesDir.setText(current.dictionariesDir().toString());
+        kindlingCliPath.setText(current.kindlingCliPath().map(Path::toString).orElse(""));
+        kindlingCliPath.setPromptText("Leave empty to use PATH, cache, or download");
+        kindlingVersion.setText(current.kindlingVersion().orElse(""));
+        kindlingVersion.setPromptText(KindlingRelease.load().version() + " (pinned default)");
+
+        getDialogPane().setContent(buildForm());
+        setResultConverter(button -> button == ButtonType.OK ? toPreferences() : null);
+    }
+
+    private GridPane buildForm() {
+        GridPane grid = new GridPane();
+        grid.setHgap(8);
+        grid.setVgap(10);
+        grid.setPadding(new Insets(12));
+
+        grid.addRow(0, new Label("Dumps folder"), withDirectoryChooser(dumpsDir, "Choose dumps folder"));
+        grid.addRow(1, new Label("Dictionaries folder"),
+                    withDirectoryChooser(dictionariesDir, "Choose dictionaries folder"));
+        grid.addRow(2, new Label("kindling-cli binary"), withFileChooser(kindlingCliPath));
+        grid.addRow(3, new Label("kindling version"), kindlingVersion);
+        grid.add(memoryLabel(), 1, 4);
+
+        GridPane.setHgrow(dumpsDir, Priority.ALWAYS);
+        return grid;
+    }
+
+    private HBox withDirectoryChooser(TextField field, String chooserTitle) {
+        Button browse = new Button("Browse…");
+        browse.setOnAction(_ -> {
+            DirectoryChooser chooser = new DirectoryChooser();
+            chooser.setTitle(chooserTitle);
+            initialDirectory(field.getText()).ifPresent(chooser::setInitialDirectory);
+            File chosen = chooser.showDialog(getOwner());
+            if (chosen != null) {
+                field.setText(chosen.getAbsolutePath());
+            }
+        });
+        return row(field, browse);
+    }
+
+    private HBox withFileChooser(TextField field) {
+        Button browse = new Button("Browse…");
+        browse.setOnAction(_ -> {
+            FileChooser chooser = new FileChooser();
+            chooser.setTitle("Choose kindling-cli binary");
+            File chosen = chooser.showOpenDialog(getOwner());
+            if (chosen != null) {
+                field.setText(chosen.getAbsolutePath());
+            }
+        });
+        return row(field, browse);
+    }
+
+    private static HBox row(TextField field, Button browse) {
+        field.setPrefColumnCount(28);
+        HBox box = new HBox(6, field, browse);
+        HBox.setHgrow(field, Priority.ALWAYS);
+        return box;
+    }
+
+    private static Optional<File> initialDirectory(String text) {
+        if (text == null || text.isBlank()) {
+            return Optional.empty();
+        }
+        File dir = new File(text);
+        return dir.isDirectory() ? Optional.of(dir) : Optional.empty();
+    }
+
+    private static Label memoryLabel() {
+        long maxHeapMb = Runtime.getRuntime().maxMemory() / BYTES_PER_MB;
+        Label label = new Label(memoryText(maxHeapMb));
+        label.setWrapText(true);
+        if (maxHeapMb < LOW_HEAP_THRESHOLD_MB) {
+            label.getStyleClass().add("warning-label");
+        }
+        return label;
+    }
+
+    static String memoryText(long maxHeapMb) {
+        String base = "Max heap: %d MB (set at startup, not adjustable here)".formatted(maxHeapMb);
+        if (maxHeapMb < LOW_HEAP_THRESHOLD_MB) {
+            return base + " — the largest editions, such as English, may run out of memory.";
+        }
+        return base;
+    }
+
+    private Preferences toPreferences() {
+        return new Preferences(Path.of(dumpsDir.getText().strip()),
+                               Path.of(dictionariesDir.getText().strip()),
+                               optionalPath(kindlingCliPath.getText()),
+                               optionalText(kindlingVersion.getText()));
+    }
+
+    private static Optional<String> optionalText(String text) {
+        return Optional.ofNullable(text).map(String::strip).filter(s -> !s.isEmpty());
+    }
+
+    private static Optional<Path> optionalPath(String text) {
+        return optionalText(text).map(Path::of);
+    }
+}

--- a/src/main/java/edu/self/w2k/gui/ProgressSnapshot.java
+++ b/src/main/java/edu/self/w2k/gui/ProgressSnapshot.java
@@ -1,0 +1,66 @@
+package edu.self.w2k.gui;
+
+import edu.self.w2k.progress.ProgressListener;
+import edu.self.w2k.progress.ProgressListener.Stage;
+
+/**
+ * A {@link ProgressListener} callback rendered for display: a bar fraction plus a status line.
+ * <p>
+ * Progress is reported <em>per stage</em> rather than as one overall figure. A combined number would
+ * need weights for how long each stage takes relative to the others, and those ratios swing wildly
+ * with dump size and language — a bar that jumps to 90% and sits there is worse than an honest
+ * per-stage bar with the stage named next to it.
+ *
+ * @param fraction 0.0–1.0, or {@link #INDETERMINATE} when the total is unknown
+ * @param message  status line for the user
+ */
+public record ProgressSnapshot(double fraction, String message) {
+
+    /** Matches {@code ProgressIndicator.INDETERMINATE_PROGRESS}, so it can be bound straight to a bar. */
+    public static final double INDETERMINATE = -1;
+
+    private static final long BYTES_PER_MB = 1024L * 1024L;
+
+    public static ProgressSnapshot idle() {
+        return new ProgressSnapshot(0, "Ready");
+    }
+
+    public static ProgressSnapshot of(Stage stage, long done, long total) {
+        return switch (stage) {
+            case DOWNLOAD -> new ProgressSnapshot(fraction(done, total), downloadMessage(done, total));
+            case PARSE -> new ProgressSnapshot(fraction(done, total),
+                                               "Parsing entries… " + percent(done, total));
+            case FOLD -> new ProgressSnapshot(INDETERMINATE, "Folding inflected forms…");
+            case WRITE_HTML -> new ProgressSnapshot(fraction(done, total),
+                                                    "Writing HTML %d of %d…".formatted(done, total));
+            case KINDLING -> new ProgressSnapshot(INDETERMINATE, "Building MOBI with kindling-cli…");
+        };
+    }
+
+    private static String downloadMessage(long done, long total) {
+        if (total <= 0) {
+            return "Downloading dump… %d MB".formatted(done / BYTES_PER_MB);
+        }
+        return "Downloading dump… %s (%d of %d MB)"
+                .formatted(percent(done, total), done / BYTES_PER_MB, total / BYTES_PER_MB);
+    }
+
+    private static double fraction(long done, long total) {
+        if (total <= 0) {
+            return INDETERMINATE;
+        }
+        return Math.clamp((double) done / total, 0.0, 1.0);
+    }
+
+    private static String percent(long done, long total) {
+        if (total <= 0) {
+            return "";
+        }
+        return Math.round(fraction(done, total) * 100) + "%";
+    }
+
+    /** True when the total was reported as {@link ProgressListener#TOTAL_UNKNOWN}. */
+    public boolean indeterminate() {
+        return fraction == INDETERMINATE;
+    }
+}

--- a/src/main/java/edu/self/w2k/gui/UiLogAppender.java
+++ b/src/main/java/edu/self/w2k/gui/UiLogAppender.java
@@ -1,0 +1,93 @@
+package edu.self.w2k.gui;
+
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Collection;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicLong;
+
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+
+/**
+ * Buffers log events for display in the GUI's console pane.
+ * <p>
+ * The appender only <em>enqueues</em>; the UI drains it in batches on a timer. Pushing each event
+ * straight to the FX thread with {@code Platform.runLater} would be a mistake here: a dump produces
+ * far more log traffic than a UI can repaint, and one runnable per event floods the event queue and
+ * freezes the window — the very thing the progress bar exists to avoid.
+ * <p>
+ * The queue is bounded and drops the newest event when full, counting drops rather than blocking:
+ * blocking would apply back-pressure to the worker thread and slow the actual work down just because
+ * the UI cannot keep up.
+ */
+public class UiLogAppender extends AppenderBase<ILoggingEvent> {
+
+    static final int DEFAULT_CAPACITY = 4096;
+
+    /**
+     * Zoned explicitly: {@link ILoggingEvent#getInstant()} is an {@link java.time.Instant}, which
+     * carries no offset, and a bare wall-clock pattern cannot format one.
+     */
+    private static final DateTimeFormatter TIME =
+            DateTimeFormatter.ofPattern("HH:mm:ss").withZone(ZoneId.systemDefault());
+
+    private final BlockingQueue<String> queue;
+    private final AtomicLong dropped = new AtomicLong();
+
+    public UiLogAppender() {
+        this(DEFAULT_CAPACITY);
+    }
+
+    public UiLogAppender(int capacity) {
+        this.queue = new ArrayBlockingQueue<>(capacity);
+        setName("ui");
+    }
+
+    @Override
+    protected void append(ILoggingEvent event) {
+        if (!queue.offer(format(event))) {
+            dropped.incrementAndGet();
+        }
+    }
+
+    /**
+     * Moves up to {@code max} buffered lines into {@code sink}.
+     *
+     * @return how many lines were transferred
+     */
+    public int drainTo(Collection<? super String> sink, int max) {
+        return queue.drainTo(sink, max);
+    }
+
+    /** Lines discarded because the buffer was full; non-zero means the console is not complete. */
+    public long droppedCount() {
+        return dropped.get();
+    }
+
+    /**
+     * Mirrors the console pattern in {@code logback.xml} so the GUI and the CLI read alike. A
+     * throwable's message is appended inline — without it, a stack-trace-only failure would show up
+     * in the pane as a bare "Download failed" with no cause.
+     */
+    static String format(ILoggingEvent event) {
+        StringBuilder line = new StringBuilder()
+                .append(TIME.format(event.getInstant()))
+                .append(' ')
+                .append("%-5s".formatted(event.getLevel()))
+                .append(" - ")
+                .append(event.getFormattedMessage());
+
+        IThrowableProxy thrown = event.getThrowableProxy();
+        if (thrown != null) {
+            line.append(" (").append(thrown.getClassName());
+            if (thrown.getMessage() != null) {
+                line.append(": ").append(thrown.getMessage());
+            }
+            line.append(')');
+        }
+        return line.toString();
+    }
+}

--- a/src/main/java/edu/self/w2k/pipeline/DictionaryPipeline.java
+++ b/src/main/java/edu/self/w2k/pipeline/DictionaryPipeline.java
@@ -1,0 +1,118 @@
+package edu.self.w2k.pipeline;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.function.Consumer;
+
+import edu.self.w2k.command.GenerateCommand;
+import edu.self.w2k.config.Preferences;
+import edu.self.w2k.download.DownloadResult;
+import edu.self.w2k.download.DumpDownloader;
+import edu.self.w2k.download.KaikkiDumpDownloader;
+import edu.self.w2k.kindling.KindlingCliResolver;
+import edu.self.w2k.kindling.KindlingDictionaryConverter;
+import edu.self.w2k.kindling.KindlingDownloader;
+import edu.self.w2k.kindling.KindlingRelease;
+import edu.self.w2k.parse.JsonlDictionaryParser;
+import edu.self.w2k.progress.ProgressListener;
+import edu.self.w2k.render.HtmlDefinitionRenderer;
+import edu.self.w2k.write.DictionaryTitles;
+import edu.self.w2k.write.opf.OpfDictionaryWriter;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * The combined download-then-generate flow behind the GUI's single button.
+ * <p>
+ * Deliberately free of JavaFX: the orchestration is the part worth testing, and tangling it with
+ * {@code javafx.concurrent.Task} would make it reachable only through a UI test. The GUI's
+ * {@code PipelineTask} is a thin wrapper that adds cancellation and thread management.
+ * <p>
+ * The two collaborators are injectable so a test can substitute them; the defaults hold the real
+ * wiring.
+ */
+@Slf4j
+public class DictionaryPipeline {
+
+    /** Obtains the dump for an edition, downloading it if it is not already on disk. */
+    @FunctionalInterface
+    public interface DownloaderFactory {
+        DumpDownloader create(String editionLang, Path dumpsDir, ProgressListener progress);
+    }
+
+    /**
+     * Turns a downloaded dump into a dictionary.
+     *
+     * @param onKindlingStart receives the kindling-cli process so a caller can destroy it on cancel
+     */
+    @FunctionalInterface
+    public interface Generator {
+        Path generate(Path dumpFile,
+                      Preferences prefs,
+                      String wordLang,
+                      String editionLang,
+                      ProgressListener progress,
+                      Consumer<Process> onKindlingStart) throws IOException;
+    }
+
+    private final DownloaderFactory downloaderFactory;
+    private final Generator generator;
+
+    public DictionaryPipeline() {
+        this(KaikkiDumpDownloader::new, DictionaryPipeline::generateWithKindling);
+    }
+
+    public DictionaryPipeline(DownloaderFactory downloaderFactory, Generator generator) {
+        this.downloaderFactory = downloaderFactory;
+        this.generator = generator;
+    }
+
+    /**
+     * Downloads the dump if needed, then generates the dictionary.
+     *
+     * @return the generated {@code .mobi}
+     */
+    public Path run(Preferences prefs,
+                    String editionLang,
+                    String wordLang,
+                    ProgressListener progress,
+                    Consumer<Process> onKindlingStart) throws IOException {
+
+        DownloadResult download =
+                downloaderFactory.create(editionLang, prefs.dumpsDir(), progress).download();
+        if (download.alreadyPresent()) {
+            log.info("Using already-downloaded dump: {}", download.dumpPath());
+        }
+
+        return generator.generate(download.dumpPath(), prefs, wordLang, editionLang,
+                                  progress, onKindlingStart);
+    }
+
+    private static Path generateWithKindling(Path dumpFile,
+                                             Preferences prefs,
+                                             String wordLang,
+                                             String editionLang,
+                                             ProgressListener progress,
+                                             Consumer<Process> onKindlingStart) throws IOException {
+        String version = prefs.kindlingVersion().orElseGet(() -> KindlingRelease.load().version());
+        KindlingCliResolver resolver =
+                new KindlingCliResolver(version, prefs.kindlingCliPath(), new KindlingDownloader());
+
+        KindlingDictionaryConverter writer = new KindlingDictionaryConverter(
+                new OpfDictionaryWriter(progress),
+                resolver,
+                KindlingDictionaryConverter.defaultRunner(onKindlingStart),
+                progress);
+
+        return new GenerateCommand(
+                new JsonlDictionaryParser(progress),
+                new HtmlDefinitionRenderer(),
+                writer,
+                dumpFile,
+                prefs.dictionariesDir(),
+                wordLang,
+                editionLang,
+                DictionaryTitles.autoTitle(wordLang, editionLang),
+                progress
+        ).execute();
+    }
+}

--- a/src/main/resources/edu/self/w2k/gui/app.css
+++ b/src/main/resources/edu/self/w2k/gui/app.css
@@ -1,0 +1,46 @@
+/* Styling for the wiktionary-to-kindle desktop app. */
+
+.root {
+    -fx-font-family: -apple-system, "Segoe UI", "Inter", "Helvetica Neue", sans-serif;
+    -fx-font-size: 13px;
+}
+
+.section-label {
+    -fx-font-weight: bold;
+    -fx-opacity: 0.75;
+}
+
+.title-preview {
+    -fx-font-weight: bold;
+}
+
+.status-label {
+    -fx-opacity: 0.8;
+}
+
+.path-label {
+    -fx-opacity: 0.6;
+    -fx-font-size: 11px;
+}
+
+.warning-label {
+    -fx-text-fill: #b06000;
+}
+
+/* The console is read as a stream of timestamped lines, so it needs a monospaced grid. */
+.log-view {
+    -fx-font-family: "SF Mono", "Cascadia Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+    -fx-font-size: 11.5px;
+}
+
+.log-view .list-cell {
+    -fx-padding: 1 6 1 6;
+}
+
+.log-view .list-cell:filled:selected {
+    -fx-background-color: -fx-selection-bar;
+}
+
+.progress-bar {
+    -fx-pref-height: 14px;
+}

--- a/src/main/resources/edu/self/w2k/gui/main.fxml
+++ b/src/main/resources/edu/self/w2k/gui/main.fxml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.ComboBox?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.control.Menu?>
+<?import javafx.scene.control.MenuBar?>
+<?import javafx.scene.control.MenuItem?>
+<?import javafx.scene.control.ProgressBar?>
+<?import javafx.scene.control.Separator?>
+<?import javafx.scene.control.Tab?>
+<?import javafx.scene.control.TabPane?>
+<?import javafx.scene.control.TableColumn?>
+<?import javafx.scene.control.TableView?>
+<?import javafx.scene.layout.BorderPane?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Priority?>
+<?import javafx.scene.layout.VBox?>
+
+<!--
+    fx:controller declares the type; App installs a controllerFactory that constructs it with the log
+    appender. The declaration is required even with a factory — FXMLLoader only consults the factory
+    once it knows which controller class to ask for.
+-->
+<BorderPane xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml"
+            fx:controller="edu.self.w2k.gui.MainController">
+
+    <top>
+        <MenuBar>
+            <menus>
+                <Menu text="File">
+                    <items>
+                        <MenuItem text="Preferences…" accelerator="Shortcut+COMMA" onAction="#onPreferences"/>
+                    </items>
+                </Menu>
+            </menus>
+        </MenuBar>
+    </top>
+
+    <center>
+        <TabPane tabClosingPolicy="UNAVAILABLE">
+            <tabs>
+
+                <Tab text="Build">
+                    <content>
+                        <VBox spacing="12">
+                            <padding>
+                                <Insets top="14" right="14" bottom="14" left="14"/>
+                            </padding>
+
+                            <GridPane hgap="10" vgap="10">
+                                <columnConstraints>
+                                    <ColumnConstraints minWidth="130"/>
+                                    <ColumnConstraints hgrow="ALWAYS"/>
+                                </columnConstraints>
+
+                                <Label text="Wiktionary edition" GridPane.rowIndex="0" GridPane.columnIndex="0"/>
+                                <ComboBox fx:id="editionCombo" maxWidth="Infinity"
+                                          GridPane.rowIndex="0" GridPane.columnIndex="1"/>
+
+                                <Label text="Word language" GridPane.rowIndex="1" GridPane.columnIndex="0"/>
+                                <ComboBox fx:id="wordLanguageCombo" maxWidth="Infinity"
+                                          GridPane.rowIndex="1" GridPane.columnIndex="1"/>
+
+                                <Label text="Dictionary title" GridPane.rowIndex="2" GridPane.columnIndex="0"/>
+                                <Label fx:id="titlePreview" styleClass="title-preview"
+                                       GridPane.rowIndex="2" GridPane.columnIndex="1"/>
+                            </GridPane>
+
+                            <HBox spacing="8">
+                                <Button fx:id="startButton" text="Build dictionary"
+                                        defaultButton="true" onAction="#onStart"/>
+                                <Button fx:id="cancelButton" text="Cancel" onAction="#onCancel"/>
+                                <Button fx:id="revealButton" text="Show in folder" onAction="#onReveal"/>
+                            </HBox>
+
+                            <Separator/>
+
+                            <VBox spacing="6">
+                                <ProgressBar fx:id="progressBar" progress="0" maxWidth="Infinity"/>
+                                <Label fx:id="statusLabel" styleClass="status-label"/>
+                            </VBox>
+
+                            <Label text="Log" styleClass="section-label"/>
+                            <ListView fx:id="logView" styleClass="log-view" VBox.vgrow="ALWAYS"/>
+                        </VBox>
+                    </content>
+                </Tab>
+
+                <Tab text="Dumps">
+                    <content>
+                        <VBox spacing="10">
+                            <padding>
+                                <Insets top="14" right="14" bottom="14" left="14"/>
+                            </padding>
+
+                            <TableView fx:id="dumpsTable" VBox.vgrow="ALWAYS">
+                                <columns>
+                                    <TableColumn fx:id="dumpLangColumn" text="Edition" prefWidth="110"/>
+                                    <TableColumn fx:id="dumpDateColumn" text="Generated" prefWidth="140"/>
+                                    <TableColumn fx:id="dumpSizeColumn" text="Size" prefWidth="100"/>
+                                </columns>
+                            </TableView>
+
+                            <HBox spacing="8">
+                                <Button text="Refresh" onAction="#onRefreshDumps"/>
+                                <Button fx:id="deleteDumpButton" text="Delete" onAction="#onDeleteDump"/>
+                            </HBox>
+
+                            <Label fx:id="dumpsLocationLabel" styleClass="path-label"/>
+                        </VBox>
+                    </content>
+                </Tab>
+
+            </tabs>
+        </TabPane>
+    </center>
+
+</BorderPane>

--- a/src/test/java/edu/self/w2k/gui/ByteSizesTest.java
+++ b/src/test/java/edu/self/w2k/gui/ByteSizesTest.java
@@ -1,0 +1,31 @@
+package edu.self.w2k.gui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class ByteSizesTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "0, 0 KB",
+            "2048, 2 KB",
+            "1048575, 1023 KB",
+            "1048576, 1 MB",
+            "110100480, 105 MB",
+            "1073741824, 1.0 GB",
+            "1610612736, 1.5 GB",
+    })
+    void should_scale_unit_to_magnitude(long bytes, String expected) {
+        // When / Then
+        assertThat(ByteSizes.format(bytes)).isEqualTo(expected);
+    }
+
+    @Test
+    void should_render_question_mark_when_size_is_unknown() {
+        // Given the sentinel DumpCatalog uses when a file's size cannot be read
+        assertThat(ByteSizes.format(-1)).isEqualTo("?");
+    }
+}

--- a/src/test/java/edu/self/w2k/gui/LanguageConverterTest.java
+++ b/src/test/java/edu/self/w2k/gui/LanguageConverterTest.java
@@ -1,0 +1,68 @@
+package edu.self.w2k.gui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import edu.self.w2k.config.LanguageCatalog.Language;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class LanguageConverterTest {
+
+    private final LanguageConverter unit = new LanguageConverter();
+
+    @Test
+    void should_render_name_and_code_when_converting_to_string() {
+        // When / Then
+        assertThat(unit.toString(Language.of("fr"))).isEqualTo("French (fr)");
+    }
+
+    @Test
+    void should_render_empty_string_when_language_is_null() {
+        // When / Then
+        assertThat(unit.toString(null)).isEmpty();
+    }
+
+    @Test
+    void should_round_trip_a_rendered_language() {
+        // Given
+        Language original = Language.of("fr");
+
+        // When
+        Language parsed = unit.fromString(unit.toString(original));
+
+        // Then
+        assertThat(parsed).isEqualTo(original);
+    }
+
+    @Test
+    void should_accept_a_bare_code_when_typed_by_hand() {
+        // Given kaikki adds editions between releases, so a code absent from the list must still work
+        Language parsed = unit.fromString("nds");
+
+        // Then
+        assertThat(parsed.code()).isEqualTo("nds");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"  fr  ", "French (fr)", " French (fr) ", "Anything (fr)"})
+    void should_extract_the_code_regardless_of_surrounding_text(String input) {
+        // When / Then
+        assertThat(unit.fromString(input).code()).isEqualTo("fr");
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"   "})
+    void should_return_null_when_text_is_absent(String input) {
+        // When / Then
+        assertThat(unit.fromString(input)).isNull();
+    }
+
+    @Test
+    void should_return_null_when_parentheses_are_empty() {
+        // When / Then
+        assertThat(unit.fromString("Nothing ()")).isNull();
+    }
+}

--- a/src/test/java/edu/self/w2k/gui/MainFxmlLoadTest.java
+++ b/src/test/java/edu/self/w2k/gui/MainFxmlLoadTest.java
@@ -1,0 +1,145 @@
+package edu.self.w2k.gui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.abort;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javafx.application.Platform;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Parent;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.TableView;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Loads {@code main.fxml} for real, because nothing else catches a mistake in it: a misspelled
+ * {@code fx:id} or a handler name that no longer exists compiles fine and fails only at runtime, when
+ * the window refuses to open.
+ * <p>
+ * Needs a graphics toolkit, so it self-skips when none is available and runs under {@code xvfb-run}
+ * in CI. OpenJFX does not publish Monocle artifacts for this release line, so a truly headless
+ * variant is not currently an option.
+ */
+class MainFxmlLoadTest {
+
+    private static boolean toolkitReady;
+
+    @BeforeAll
+    static void startToolkit() {
+        try {
+            CountDownLatch started = new CountDownLatch(1);
+            Platform.startup(started::countDown);
+            toolkitReady = started.await(30, TimeUnit.SECONDS);
+        }
+        catch (IllegalStateException _) {
+            // Already started by an earlier test class in the same forked JVM.
+            toolkitReady = true;
+        }
+        catch (UnsupportedOperationException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            toolkitReady = false;
+        }
+        catch (Error e) {
+            // No display, or the native libraries cannot initialise.
+            toolkitReady = false;
+        }
+    }
+
+    @Test
+    void should_load_main_fxml_and_inject_every_field() throws Exception {
+        if (!toolkitReady) {
+            abort("No JavaFX toolkit available (expected outside CI's xvfb and on headless machines)");
+        }
+
+        AtomicReference<Parent> root = new AtomicReference<>();
+        AtomicReference<MainController> controller = new AtomicReference<>();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        CountDownLatch done = new CountDownLatch(1);
+
+        Platform.runLater(() -> {
+            try {
+                FXMLLoader loader = new FXMLLoader(App.class.getResource(App.MAIN_FXML));
+                loader.setControllerFactory(_ -> new MainController(new UiLogAppender()));
+                root.set(loader.load());
+                controller.set(loader.getController());
+            }
+            catch (Throwable t) {
+                failure.set(t);
+            }
+            finally {
+                done.countDown();
+            }
+        });
+
+        assertThat(done.await(30, TimeUnit.SECONDS)).as("FXML load timed out").isTrue();
+        assertThat(failure.get()).as("FXML failed to load").isNull();
+        assertThat(root.get()).isNotNull();
+
+        // A null field here means an fx:id in the FXML no longer matches the controller.
+        assertThat(controller.get()).isNotNull();
+        assertFieldsInjected(controller.get());
+    }
+
+    private static void assertFieldsInjected(MainController controller) throws Exception {
+        for (var field : MainController.class.getDeclaredFields()) {
+            if (field.isAnnotationPresent(javafx.fxml.FXML.class)) {
+                field.setAccessible(true);
+                assertThat(field.get(controller))
+                        .as("@FXML field '%s' was not injected — check its fx:id in main.fxml",
+                            field.getName())
+                        .isNotNull();
+            }
+        }
+    }
+
+    @Test
+    void should_populate_language_pickers_and_dumps_table_on_load() throws Exception {
+        if (!toolkitReady) {
+            abort("No JavaFX toolkit available");
+        }
+
+        AtomicReference<MainController> controller = new AtomicReference<>();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        CountDownLatch done = new CountDownLatch(1);
+
+        Platform.runLater(() -> {
+            try {
+                FXMLLoader loader = new FXMLLoader(App.class.getResource(App.MAIN_FXML));
+                loader.setControllerFactory(_ -> new MainController(new UiLogAppender()));
+                loader.load();
+                controller.set(loader.getController());
+            }
+            catch (Throwable t) {
+                failure.set(t);
+            }
+            finally {
+                done.countDown();
+            }
+        });
+
+        assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+        assertThat(failure.get()).isNull();
+
+        var editionCombo = readField(controller.get(), "editionCombo", ComboBox.class);
+        var wordCombo = readField(controller.get(), "wordLanguageCombo", ComboBox.class);
+        var dumpsTable = readField(controller.get(), "dumpsTable", TableView.class);
+
+        assertThat(editionCombo.getItems()).isNotEmpty();
+        assertThat(editionCombo.isEditable()).as("edition box must accept a hand-typed code").isTrue();
+        assertThat(wordCombo.getItems()).hasSizeGreaterThan(150);
+        assertThat(dumpsTable.getColumns()).hasSize(3);
+    }
+
+    private static <T> T readField(MainController controller, String name, Class<T> type)
+            throws Exception {
+        var field = MainController.class.getDeclaredField(name);
+        field.setAccessible(true);
+        return type.cast(field.get(controller));
+    }
+}

--- a/src/test/java/edu/self/w2k/gui/MainViewModelTest.java
+++ b/src/test/java/edu/self/w2k/gui/MainViewModelTest.java
@@ -1,0 +1,180 @@
+package edu.self.w2k.gui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import edu.self.w2k.config.LanguageCatalog.Language;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises the view model without an FX toolkit — properties, bindings and observable lists all come
+ * from javafx.base, which needs no {@code Platform.startup} and loads no native libraries. This is
+ * the reason the logic lives here rather than in the FXML controller.
+ */
+class MainViewModelTest {
+
+    private MainViewModel unit;
+
+    @BeforeEach
+    void setUp() {
+        unit = new MainViewModel();
+    }
+
+    @Test
+    void should_not_be_startable_until_both_languages_are_chosen() {
+        // Then
+        assertThat(unit.startableProperty().get()).isFalse();
+
+        // When
+        unit.editionProperty().set(Language.of("el"));
+
+        // Then
+        assertThat(unit.startableProperty().get()).isFalse();
+
+        // When
+        unit.wordLanguageProperty().set(Language.of("en"));
+
+        // Then
+        assertThat(unit.startableProperty().get()).isTrue();
+    }
+
+    @Test
+    void should_not_be_startable_while_running() {
+        // Given
+        unit.editionProperty().set(Language.of("el"));
+        unit.wordLanguageProperty().set(Language.of("en"));
+
+        // When
+        unit.runningProperty().set(true);
+
+        // Then
+        assertThat(unit.startableProperty().get()).isFalse();
+
+        // When
+        unit.runningProperty().set(false);
+
+        // Then
+        assertThat(unit.startableProperty().get()).isTrue();
+    }
+
+    @Test
+    void should_derive_title_from_word_language_and_edition() {
+        // When
+        unit.editionProperty().set(Language.of("el"));
+        unit.wordLanguageProperty().set(Language.of("fr"));
+
+        // Then — argument order matches the CLI: word language first, edition second
+        assertThat(unit.titleProperty().get()).isEqualTo("French–Greek Dictionary");
+    }
+
+    @Test
+    void should_leave_title_blank_until_both_languages_are_chosen() {
+        // When
+        unit.editionProperty().set(Language.of("el"));
+
+        // Then
+        assertThat(unit.titleProperty().get()).isEmpty();
+    }
+
+    @Test
+    void should_update_title_when_a_language_changes() {
+        // Given
+        unit.editionProperty().set(Language.of("el"));
+        unit.wordLanguageProperty().set(Language.of("fr"));
+
+        // When
+        unit.wordLanguageProperty().set(Language.of("de"));
+
+        // Then
+        assertThat(unit.titleProperty().get()).isEqualTo("German–Greek Dictionary");
+    }
+
+    @Test
+    void should_append_log_lines_in_order() {
+        // When
+        unit.appendLog(List.of("one", "two"));
+        unit.appendLog(List.of("three"));
+
+        // Then
+        assertThat(unit.getLogLines()).containsExactly("one", "two", "three");
+    }
+
+    @Test
+    void should_ignore_an_empty_batch_when_appending() {
+        // Given
+        unit.appendLog(List.of("one"));
+
+        // When
+        unit.appendLog(List.of());
+
+        // Then
+        assertThat(unit.getLogLines()).containsExactly("one");
+    }
+
+    @Test
+    void should_drop_oldest_lines_when_exceeding_the_cap() {
+        // Given a batch larger than the cap in one go
+        List<String> flood = IntStream.range(0, MainViewModel.MAX_LOG_LINES + 250)
+                .mapToObj(i -> "line " + i)
+                .toList();
+
+        // When
+        unit.appendLog(flood);
+
+        // Then
+        assertThat(unit.getLogLines()).hasSize(MainViewModel.MAX_LOG_LINES);
+        assertThat(unit.getLogLines().getFirst()).isEqualTo("line 250");
+        assertThat(unit.getLogLines().getLast()).isEqualTo("line " + (flood.size() - 1));
+    }
+
+    @Test
+    void should_keep_the_cap_across_several_batches() {
+        // When
+        for (int i = 0; i < 12; i++) {
+            int batchStart = i * 500;
+            unit.appendLog(IntStream.range(batchStart, batchStart + 500)
+                                   .mapToObj(n -> "line " + n)
+                                   .toList());
+        }
+
+        // Then
+        assertThat(unit.getLogLines()).hasSize(MainViewModel.MAX_LOG_LINES);
+        assertThat(unit.getLogLines().getLast()).isEqualTo("line 5999");
+    }
+
+    @Test
+    void should_empty_the_console_when_cleared() {
+        // Given
+        unit.appendLog(List.of("one", "two"));
+
+        // When
+        unit.clearLog();
+
+        // Then
+        assertThat(unit.getLogLines()).isEmpty();
+    }
+
+    @Test
+    void should_start_idle_and_accept_progress_reports() {
+        // Then
+        assertThat(unit.progressProperty().get()).isEqualTo(ProgressSnapshot.idle());
+
+        // When
+        ProgressSnapshot snapshot = new ProgressSnapshot(0.5, "halfway");
+        unit.report(snapshot);
+
+        // Then
+        assertThat(unit.progressProperty().get()).isEqualTo(snapshot);
+    }
+
+    @Test
+    void should_default_preferences_so_the_dumps_pane_has_a_location_before_loading() {
+        // Then
+        assertThat(unit.preferencesProperty().get()).isNotNull();
+        assertThat(unit.getDumps()).isEmpty();
+        assertThat(unit.lastOutputProperty().get()).isNull();
+    }
+}

--- a/src/test/java/edu/self/w2k/gui/PipelineTaskTest.java
+++ b/src/test/java/edu/self/w2k/gui/PipelineTaskTest.java
@@ -1,0 +1,139 @@
+package edu.self.w2k.gui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import edu.self.w2k.config.Preferences;
+import edu.self.w2k.download.DownloadResult;
+import edu.self.w2k.gui.PipelineService.PipelineTask;
+import edu.self.w2k.pipeline.DictionaryPipeline;
+import edu.self.w2k.progress.ProgressListener;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the Task wrapper directly. {@code Task} itself needs no toolkit — only its
+ * {@code Platform.runLater} state callbacks do — so {@code call()} can be invoked in-line.
+ */
+class PipelineTaskTest {
+
+    private static final Preferences PREFS = new Preferences(Path.of("/data/dumps"),
+                                                             Path.of("/data/dictionaries"),
+                                                             Optional.empty(),
+                                                             Optional.empty());
+
+    private static final Path DUMP = Path.of("/data/dumps/raw-wiktextract-data-el-2026-07-24.jsonl.gz");
+    private static final Path MOBI = Path.of("/data/dictionaries/dictionary-en-el.mobi");
+
+    @Test
+    void should_return_the_generated_path_when_called() throws Exception {
+        // Given
+        DictionaryPipeline pipeline = new DictionaryPipeline(
+                (_, _, _) -> () -> new DownloadResult(DUMP, false),
+                (_, _, _, _, _, _) -> MOBI);
+        PipelineTask task = new PipelineTask(pipeline, PREFS, "el", "en", ProgressListener.NOOP);
+
+        // When / Then
+        assertThat(task.call()).isEqualTo(MOBI);
+    }
+
+    @Test
+    void should_destroy_kindling_process_when_cancelled_mid_build() throws Exception {
+        // Given a real long-running subprocess standing in for kindling-cli, registered through the
+        // same callback the converter uses
+        Process sleeper = new ProcessBuilder("sleep", "30").start();
+        DictionaryPipeline pipeline = new DictionaryPipeline(
+                (_, _, _) -> () -> new DownloadResult(DUMP, false),
+                (_, _, _, _, _, onKindlingStart) -> {
+                    onKindlingStart.accept(sleeper);
+                    return MOBI;
+                });
+        PipelineTask task = new PipelineTask(pipeline, PREFS, "el", "en", ProgressListener.NOOP);
+        task.call();
+        assertThat(sleeper.isAlive()).isTrue();
+
+        // When
+        task.terminateKindling();
+
+        // Then — interrupting the waiting thread alone would leave this process running
+        assertThat(sleeper.waitFor(20, TimeUnit.SECONDS)).isTrue();
+        assertThat(sleeper.isAlive()).isFalse();
+    }
+
+    @Test
+    void should_do_nothing_when_cancelled_before_kindling_starts() {
+        // Given
+        DictionaryPipeline pipeline = new DictionaryPipeline(
+                (_, _, _) -> () -> new DownloadResult(DUMP, false),
+                (_, _, _, _, _, _) -> MOBI);
+        PipelineTask task = new PipelineTask(pipeline, PREFS, "el", "en", ProgressListener.NOOP);
+
+        // When / Then — cancelling during download must not blow up on a null process
+        task.terminateKindling();
+    }
+
+    @Test
+    void should_tolerate_an_already_finished_process_when_cancelled() throws Exception {
+        // Given
+        Process finished = new ProcessBuilder("true").start();
+        finished.waitFor();
+        DictionaryPipeline pipeline = new DictionaryPipeline(
+                (_, _, _) -> () -> new DownloadResult(DUMP, false),
+                (_, _, _, _, _, onKindlingStart) -> {
+                    onKindlingStart.accept(finished);
+                    return MOBI;
+                });
+        PipelineTask task = new PipelineTask(pipeline, PREFS, "el", "en", ProgressListener.NOOP);
+        task.call();
+
+        // When / Then
+        task.terminateKindling();
+        assertThat(finished.isAlive()).isFalse();
+    }
+
+    @Test
+    void should_propagate_pipeline_failure_when_called() {
+        // Given
+        DictionaryPipeline pipeline = new DictionaryPipeline(
+                (_, _, _) -> () -> {
+                    throw new java.io.IOException("HTTP 503");
+                },
+                (_, _, _, _, _, _) -> MOBI);
+        PipelineTask task = new PipelineTask(pipeline, PREFS, "el", "en", ProgressListener.NOOP);
+
+        // When / Then
+        org.assertj.core.api.Assertions.assertThatIOException()
+                .isThrownBy(task::call)
+                .withMessage("HTTP 503");
+    }
+
+    @Test
+    void should_use_the_view_models_selection_when_creating_a_task() {
+        // Given
+        MainViewModel viewModel = new MainViewModel();
+        viewModel.preferencesProperty().set(PREFS);
+        viewModel.editionProperty().set(edu.self.w2k.config.LanguageCatalog.Language.of("el"));
+        viewModel.wordLanguageProperty().set(edu.self.w2k.config.LanguageCatalog.Language.of("en"));
+
+        List<String> seen = new java.util.ArrayList<>();
+        DictionaryPipeline pipeline = new DictionaryPipeline(
+                (edition, _, _) -> {
+                    seen.add(edition);
+                    return () -> new DownloadResult(DUMP, false);
+                },
+                (_, _, wordLang, _, _, _) -> {
+                    seen.add(wordLang);
+                    return MOBI;
+                });
+        PipelineService service = new PipelineService(viewModel, ProgressListener.NOOP, pipeline);
+
+        // When
+        javafx.concurrent.Task<Path> task = service.createTask();
+
+        // Then
+        assertThat(task).isInstanceOf(PipelineTask.class);
+    }
+}

--- a/src/test/java/edu/self/w2k/gui/PreferencesDialogMemoryTest.java
+++ b/src/test/java/edu/self/w2k/gui/PreferencesDialogMemoryTest.java
@@ -1,0 +1,35 @@
+package edu.self.w2k.gui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class PreferencesDialogMemoryTest {
+
+    @Test
+    void should_state_that_heap_is_fixed_at_startup() {
+        // When
+        String text = PreferencesDialog.memoryText(8192);
+
+        // Then — the wording has to explain why this is not editable, or it reads as a broken field
+        assertThat(text).contains("8192 MB").contains("set at startup");
+    }
+
+    @Test
+    void should_warn_about_large_editions_when_heap_is_low() {
+        // When
+        String text = PreferencesDialog.memoryText(PreferencesDialog.LOW_HEAP_THRESHOLD_MB - 1);
+
+        // Then
+        assertThat(text).contains("run out of memory").contains("English");
+    }
+
+    @Test
+    void should_not_warn_when_heap_is_at_the_threshold() {
+        // When
+        String text = PreferencesDialog.memoryText(PreferencesDialog.LOW_HEAP_THRESHOLD_MB);
+
+        // Then
+        assertThat(text).doesNotContain("run out of memory");
+    }
+}

--- a/src/test/java/edu/self/w2k/gui/ProgressSnapshotTest.java
+++ b/src/test/java/edu/self/w2k/gui/ProgressSnapshotTest.java
@@ -1,0 +1,106 @@
+package edu.self.w2k.gui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import edu.self.w2k.progress.ProgressListener;
+import edu.self.w2k.progress.ProgressListener.Stage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class ProgressSnapshotTest {
+
+    private static final long MB = 1024L * 1024L;
+
+    @Test
+    void should_report_fraction_and_megabytes_when_downloading_with_known_length() {
+        // When
+        ProgressSnapshot snapshot = ProgressSnapshot.of(Stage.DOWNLOAD, 25 * MB, 100 * MB);
+
+        // Then
+        assertThat(snapshot.fraction()).isCloseTo(0.25, within(1e-9));
+        assertThat(snapshot.message()).isEqualTo("Downloading dump… 25% (25 of 100 MB)");
+    }
+
+    @Test
+    void should_be_indeterminate_when_content_length_is_unknown() {
+        // When
+        ProgressSnapshot snapshot =
+                ProgressSnapshot.of(Stage.DOWNLOAD, 7 * MB, ProgressListener.TOTAL_UNKNOWN);
+
+        // Then
+        assertThat(snapshot.indeterminate()).isTrue();
+        assertThat(snapshot.fraction()).isEqualTo(ProgressSnapshot.INDETERMINATE);
+        assertThat(snapshot.message()).isEqualTo("Downloading dump… 7 MB");
+    }
+
+    @Test
+    void should_report_percentage_when_parsing() {
+        // When
+        ProgressSnapshot snapshot = ProgressSnapshot.of(Stage.PARSE, 3, 4);
+
+        // Then
+        assertThat(snapshot.fraction()).isCloseTo(0.75, within(1e-9));
+        assertThat(snapshot.message()).isEqualTo("Parsing entries… 75%");
+    }
+
+    @Test
+    void should_report_chapter_counts_when_writing_html() {
+        // When
+        ProgressSnapshot snapshot = ProgressSnapshot.of(Stage.WRITE_HTML, 3, 7);
+
+        // Then
+        assertThat(snapshot.message()).isEqualTo("Writing HTML 3 of 7…");
+    }
+
+    @Test
+    void should_be_indeterminate_when_folding() {
+        // When
+        ProgressSnapshot snapshot = ProgressSnapshot.of(Stage.FOLD, 0, ProgressListener.TOTAL_UNKNOWN);
+
+        // Then
+        assertThat(snapshot.indeterminate()).isTrue();
+        assertThat(snapshot.message()).isEqualTo("Folding inflected forms…");
+    }
+
+    @Test
+    void should_be_indeterminate_when_running_kindling() {
+        // When
+        ProgressSnapshot snapshot = ProgressSnapshot.of(Stage.KINDLING, 0, ProgressListener.TOTAL_UNKNOWN);
+
+        // Then
+        assertThat(snapshot.indeterminate()).isTrue();
+        assertThat(snapshot.message()).contains("kindling-cli");
+    }
+
+    @Test
+    void should_clamp_fraction_when_more_bytes_arrive_than_advertised() {
+        // Given a server whose content-length understates the body
+        ProgressSnapshot snapshot = ProgressSnapshot.of(Stage.DOWNLOAD, 150 * MB, 100 * MB);
+
+        // Then the bar must not exceed full
+        assertThat(snapshot.fraction()).isEqualTo(1.0);
+    }
+
+    @ParameterizedTest
+    @EnumSource(Stage.class)
+    void should_produce_a_message_for_every_stage(Stage stage) {
+        // When
+        ProgressSnapshot snapshot = ProgressSnapshot.of(stage, 1, 2);
+
+        // Then — a new stage must not silently render as a blank status line
+        assertThat(snapshot.message()).isNotBlank();
+    }
+
+    @Test
+    void should_start_idle_and_not_indeterminate() {
+        // When
+        ProgressSnapshot idle = ProgressSnapshot.idle();
+
+        // Then
+        assertThat(idle.fraction()).isZero();
+        assertThat(idle.indeterminate()).isFalse();
+        assertThat(idle.message()).isEqualTo("Ready");
+    }
+}

--- a/src/test/java/edu/self/w2k/gui/UiLogAppenderTest.java
+++ b/src/test/java/edu/self/w2k/gui/UiLogAppenderTest.java
@@ -1,0 +1,133 @@
+package edu.self.w2k.gui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class UiLogAppenderTest {
+
+    private final LoggerContext context = new LoggerContext();
+    private UiLogAppender unit;
+
+    @BeforeEach
+    void setUp() {
+        unit = new UiLogAppender(4);
+        unit.setContext(context);
+        unit.start();
+    }
+
+    @Test
+    void should_buffer_events_until_drained() {
+        // Given
+        unit.doAppend(event(Level.INFO, "first"));
+        unit.doAppend(event(Level.INFO, "second"));
+
+        // When
+        List<String> sink = new ArrayList<>();
+        int drained = unit.drainTo(sink, 10);
+
+        // Then
+        assertThat(drained).isEqualTo(2);
+        assertThat(sink).hasSize(2);
+        assertThat(sink.getFirst()).endsWith("- first");
+        assertThat(unit.droppedCount()).isZero();
+    }
+
+    @Test
+    void should_leave_remainder_queued_when_drain_is_capped() {
+        // Given
+        unit.doAppend(event(Level.INFO, "a"));
+        unit.doAppend(event(Level.INFO, "b"));
+        unit.doAppend(event(Level.INFO, "c"));
+
+        // When
+        List<String> first = new ArrayList<>();
+        unit.drainTo(first, 2);
+        List<String> second = new ArrayList<>();
+        unit.drainTo(second, 2);
+
+        // Then
+        assertThat(first).hasSize(2);
+        assertThat(second).hasSize(1);
+    }
+
+    @Test
+    void should_drop_and_count_when_buffer_is_full_rather_than_block() {
+        // Given a capacity of 4 and six events; blocking here would slow the worker thread down
+        for (int i = 0; i < 6; i++) {
+            unit.doAppend(event(Level.INFO, "line " + i));
+        }
+
+        // When
+        List<String> sink = new ArrayList<>();
+        int drained = unit.drainTo(sink, 100);
+
+        // Then
+        assertThat(drained).isEqualTo(4);
+        assertThat(unit.droppedCount()).isEqualTo(2);
+    }
+
+    @Test
+    void should_report_nothing_drained_when_empty() {
+        // When / Then
+        assertThat(unit.drainTo(new ArrayList<>(), 10)).isZero();
+    }
+
+    @Test
+    void should_include_level_and_timestamp_when_formatting() {
+        // When
+        String line = UiLogAppender.format(event(Level.WARN, "careful"));
+
+        // Then
+        assertThat(line).matches("\\d{2}:\\d{2}:\\d{2} WARN  - careful");
+    }
+
+    @Test
+    void should_interpolate_placeholders_when_formatting() {
+        // Given
+        LoggingEvent event = event(Level.INFO, "downloaded {} of {} MB");
+        event.setArgumentArray(new Object[] {25, 100});
+
+        // When / Then
+        assertThat(UiLogAppender.format(event)).endsWith("- downloaded 25 of 100 MB");
+    }
+
+    @Test
+    void should_append_throwable_details_when_present() {
+        // Given a failure logged with an exception: without the cause the pane would show only the
+        // bare message, and the reason for the failure would be invisible.
+        LoggingEvent event = event(Level.ERROR, "Download failed");
+        event.setThrowableProxy(new ch.qos.logback.classic.spi.ThrowableProxy(
+                new java.io.IOException("HTTP 404")));
+
+        // When
+        String line = UiLogAppender.format(event);
+
+        // Then
+        assertThat(line).contains("Download failed")
+                .contains("IOException")
+                .contains("HTTP 404");
+    }
+
+    private LoggingEvent event(Level level, String message) {
+        LoggingEvent event = new LoggingEvent();
+        event.setLevel(level);
+        event.setMessage(message);
+        event.setLoggerName("test");
+        event.setTimeStamp(System.currentTimeMillis());
+        return event;
+    }
+
+    @Test
+    void should_expose_a_named_appender_so_it_can_be_found_on_the_root_logger() {
+        // When / Then
+        assertThat(unit.getName()).isEqualTo("ui");
+    }
+}

--- a/src/test/java/edu/self/w2k/pipeline/DictionaryPipelineTest.java
+++ b/src/test/java/edu/self/w2k/pipeline/DictionaryPipelineTest.java
@@ -1,0 +1,186 @@
+package edu.self.w2k.pipeline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIOException;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import edu.self.w2k.config.Preferences;
+import edu.self.w2k.download.DownloadResult;
+import edu.self.w2k.progress.ProgressListener;
+import org.junit.jupiter.api.Test;
+
+class DictionaryPipelineTest {
+
+    private static final Preferences PREFS = new Preferences(Path.of("/data/dumps"),
+                                                             Path.of("/data/dictionaries"),
+                                                             Optional.empty(),
+                                                             Optional.empty());
+
+    private static final Path DUMP = Path.of("/data/dumps/raw-wiktextract-data-el-2026-07-24.jsonl.gz");
+    private static final Path MOBI = Path.of("/data/dictionaries/dictionary-en-el.mobi");
+
+    @Test
+    void should_pass_downloaded_dump_to_the_generator() throws Exception {
+        // Given
+        AtomicReference<Path> generatedFrom = new AtomicReference<>();
+        DictionaryPipeline unit = new DictionaryPipeline(
+                (_, _, _) -> () -> new DownloadResult(DUMP, false),
+                (dumpFile, _, _, _, _, _) -> {
+                    generatedFrom.set(dumpFile);
+                    return MOBI;
+                });
+
+        // When
+        Path result = unit.run(PREFS, "el", "en", ProgressListener.NOOP, _ -> {});
+
+        // Then
+        assertThat(generatedFrom.get()).isEqualTo(DUMP);
+        assertThat(result).isEqualTo(MOBI);
+    }
+
+    @Test
+    void should_generate_from_the_existing_dump_when_already_present() throws Exception {
+        // Given a download that was skipped because the file was already on disk
+        AtomicReference<Path> generatedFrom = new AtomicReference<>();
+        DictionaryPipeline unit = new DictionaryPipeline(
+                (_, _, _) -> () -> new DownloadResult(DUMP, true),
+                (dumpFile, _, _, _, _, _) -> {
+                    generatedFrom.set(dumpFile);
+                    return MOBI;
+                });
+
+        // When
+        Path result = unit.run(PREFS, "el", "en", ProgressListener.NOOP, _ -> {});
+
+        // Then — a skipped download is a success, not a reason to stop
+        assertThat(generatedFrom.get()).isEqualTo(DUMP);
+        assertThat(result).isEqualTo(MOBI);
+    }
+
+    @Test
+    void should_pass_configured_dumps_dir_and_edition_to_the_downloader() throws Exception {
+        // Given
+        List<String> seen = new ArrayList<>();
+        DictionaryPipeline unit = new DictionaryPipeline(
+                (edition, dumpsDir, _) -> {
+                    seen.add(edition);
+                    seen.add(dumpsDir.toString());
+                    return () -> new DownloadResult(DUMP, false);
+                },
+                (_, _, _, _, _, _) -> MOBI);
+
+        // When
+        unit.run(PREFS, "el", "en", ProgressListener.NOOP, _ -> {});
+
+        // Then
+        assertThat(seen).containsExactly("el", PREFS.dumpsDir().toString());
+    }
+
+    @Test
+    void should_pass_word_language_and_edition_in_the_right_order_to_the_generator() throws Exception {
+        // Given the CLI's convention: word language is the source, edition the target
+        List<String> seen = new ArrayList<>();
+        DictionaryPipeline unit = new DictionaryPipeline(
+                (_, _, _) -> () -> new DownloadResult(DUMP, false),
+                (_, _, wordLang, editionLang, _, _) -> {
+                    seen.add(wordLang);
+                    seen.add(editionLang);
+                    return MOBI;
+                });
+
+        // When
+        unit.run(PREFS, "el", "en", ProgressListener.NOOP, _ -> {});
+
+        // Then
+        assertThat(seen).containsExactly("en", "el");
+    }
+
+    @Test
+    void should_not_generate_when_the_download_fails() throws Exception {
+        // Given
+        AtomicReference<Boolean> generated = new AtomicReference<>(false);
+        DictionaryPipeline unit = new DictionaryPipeline(
+                (_, _, _) -> () -> {
+                    throw new IOException("HTTP 404");
+                },
+                (_, _, _, _, _, _) -> {
+                    generated.set(true);
+                    return MOBI;
+                });
+
+        // When / Then
+        assertThatIOException()
+                .isThrownBy(() -> unit.run(PREFS, "zzz", "en", ProgressListener.NOOP, _ -> {}))
+                .withMessage("HTTP 404");
+        assertThat(generated.get()).isFalse();
+    }
+
+    @Test
+    void should_propagate_generation_failure() {
+        // Given
+        DictionaryPipeline unit = new DictionaryPipeline(
+                (_, _, _) -> () -> new DownloadResult(DUMP, false),
+                (_, _, _, _, _, _) -> {
+                    throw new IOException("kindling-cli exited with code 1");
+                });
+
+        // When / Then
+        assertThatIOException()
+                .isThrownBy(() -> unit.run(PREFS, "el", "en", ProgressListener.NOOP, _ -> {}))
+                .withMessageContaining("kindling-cli");
+    }
+
+    @Test
+    void should_forward_the_progress_listener_to_both_stages() throws Exception {
+        // Given
+        ProgressListener listener = (_, _, _) -> {};
+        List<ProgressListener> seen = new ArrayList<>();
+        DictionaryPipeline unit = new DictionaryPipeline(
+                (_, _, progress) -> {
+                    seen.add(progress);
+                    return () -> new DownloadResult(DUMP, false);
+                },
+                (_, _, _, _, progress, _) -> {
+                    seen.add(progress);
+                    return MOBI;
+                });
+
+        // When
+        unit.run(PREFS, "el", "en", listener, _ -> {});
+
+        // Then — a dropped listener would leave the progress bar frozen for a whole stage
+        assertThat(seen).containsExactly(listener, listener);
+    }
+
+    @Test
+    void should_forward_the_kindling_process_callback_so_cancel_can_terminate_it() throws Exception {
+        // Given
+        java.util.function.Consumer<Process> callback = _ -> {};
+        AtomicReference<Object> seen = new AtomicReference<>();
+        DictionaryPipeline unit = new DictionaryPipeline(
+                (_, _, _) -> () -> new DownloadResult(DUMP, false),
+                (_, _, _, _, _, onKindlingStart) -> {
+                    seen.set(onKindlingStart);
+                    return MOBI;
+                });
+
+        // When
+        unit.run(PREFS, "el", "en", ProgressListener.NOOP, callback);
+
+        // Then
+        assertThat(seen.get()).isSameAs(callback);
+    }
+
+    @Test
+    void should_wire_real_collaborators_when_constructed_with_defaults() {
+        // The production constructor must at least be usable; its collaborators are exercised
+        // end-to-end by the CLI tests rather than mocked here.
+        assertThat(new DictionaryPipeline()).isNotNull();
+    }
+}


### PR DESCRIPTION
Phase 3 of the desktop app (follows #65 and #66). Adds the windowed front-end: one-click download-then-generate with progress and cancel, a dump manager, and a preferences dialog. The picocli CLI is untouched and still ships as the cross-platform fat JAR.

## Where the logic lives

`MainViewModel` holds state and derivations; `ProgressSnapshot` turns a `ProgressListener` callback into a bar fraction plus a status line. Both use only `javafx.base`, which needs no `Platform.startup` and loads no natives — so they're covered by ordinary unit tests. `MainController` is left as bindings only, because a controller isn't testable.

**Progress is per-stage, not one overall number.** A combined figure needs weights for how long each stage takes relative to the others, and those ratios swing with dump size and language. An honest per-stage bar with the stage named beside it beats one that jumps to 90% and stalls.

## Two things that needed care

**Log volume.** `UiLogAppender` buffers into a bounded queue that the UI drains in batches at 10 Hz. One `Platform.runLater` per event would flood the FX queue and freeze the window — the exact thing the progress bar exists to prevent. The queue drops and *counts* when full rather than blocking, so a UI that can't keep up never slows the real work down; the drop count is surfaced when non-zero. Appenders are installed programmatically, so `logback.xml` and CLI console output are unchanged.

**Cancellation takes two mechanisms.** `cancel(true)` interrupts the worker, which covers the download and parse loops. But the kindling stage blocks in `Process.waitFor()`, where interrupting the waiter leaves the subprocess running and the MOBI half-written. `PipelineTask` tracks the process and destroys it in `cancelled()`.

## Packaging-relevant details

- **`Launcher` exists so the main class is not the `Application` subclass.** Running from the classpath is mandatory here (Jackson, logback and picocli aren't modules), and the JavaFX launcher rejects an `Application` main class with *"JavaFX runtime components are missing"*.
- **`org.openjfx` is excluded from the shaded JAR.** JavaFX resolves to a platform-classified *native* artifact, so bundling it would silently tie the CLI JAR to whichever OS built it. Verified: 0 JavaFX entries in the JAR, and the CLI still runs from it.
- **`logback-classic` moves from `runtime` to `compile` scope** — `UiLogAppender` extends `AppenderBase`, so the API is needed at compile time. Application code still logs through SLF4J only.
- `GenerateCommand` gains `execute()` returning the generated path (mirroring `DownloadCommand`), so "Show in folder" doesn't duplicate the writer's naming scheme.
- JavaFX pinned to **25.0.4**, matching `maven.compiler.release=25` and CI's JDK, rather than betting on JavaFX 26's JDK floor.

## Bug the tests caught

`UiLogAppender` formatted `ILoggingEvent.getInstant()` with a bare `HH:mm:ss` pattern. An `Instant` carries no offset, so **every line threw** `UnsupportedTemporalType` — and `AppenderBase.doAppend` swallows appender exceptions, so the console pane would have sat silently empty with no clue why. The formatter is now explicitly zoned.

## Verification

`mvnd clean verify` — **195 tests, 0 failures, 0 skipped**.

`MainFxmlLoadTest` loads `main.fxml` for real and asserts every `@FXML` field is injected. This is the one thing unit tests can't otherwise reach: a misspelled `fx:id` or a stale `onAction` handler compiles fine and fails only when the window refuses to open — which is exactly how the first launch attempt failed here (`LoadException: No controller specified`, because a `controllerFactory` is only consulted when the FXML declares `fx:controller`).

It needs a graphics toolkit and self-skips without one, so **CI now runs under `xvfb-run`**. OpenJFX publishes no Monocle artifacts for the 25.x line (checked — 404), so a fully headless variant isn't available; Xvfb is the substitute.

Also verified manually:

| check | result |
|---|---|
| `mvn javafx:run` | window opened and stayed up for 60s, no exceptions |
| log file | created at `~/.config/wiktionary-to-kindle/logs/app.log`, now non-empty (startup line records Java version, OS/arch, max heap for bug reports) |
| shaded JAR | 0 JavaFX entries |
| `generate el en` from the JAR | byte-identical 7 781 711-byte MOBI |

## Deviations from the plan

Two, both to reduce FXML wiring risk: the dumps pane is a tab in `main.fxml` under `MainController` rather than a separate `DumpsController`+FXML, and preferences is built in code rather than `preferences.fxml` — it's a four-row form, and a second FXML plus controller would add wiring to get wrong without making it clearer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)