### PR TITLE
docs: rewrite for the desktop app

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,52 +2,67 @@
 
 ## Project Overview
 
-`wiktionary-to-kindle` is a Java CLI tool that converts Wiktionary data into Kindle-compatible MOBI dictionaries. The pipeline is: **download** → **generate** (fetches `kindling-cli` on first run, then runs `kindling-cli build`).
+`wiktionary-to-kindle` converts Wiktionary data into Kindle-compatible MOBI dictionaries. The pipeline is: **download** → **generate** (fetches `kindling-cli` on first run, then runs `kindling-cli build`).
+
+Two front-ends share one service layer:
+
+- a **JavaFX desktop app** (`edu.self.w2k.gui.Launcher`), distributed as a jpackage bundle with an embedded Java runtime — the primary way users run this;
+- the original **picocli CLI** (`edu.self.w2k.CLI`), still shipped as a cross-platform fat JAR for Linux and scripted use.
+
+The service layer under `command`, `download`, `parse`, `render`, `write` and `kindling` is UI-free and shared by both. Keep it that way: anything that needs JavaFX belongs in `gui`.
 
 Data source: [kaikki.org](https://kaikki.org) pre-extracted JSONL dumps, produced weekly by [wiktextract](https://github.com/tatuylonen/wiktextract) with all Lua templates fully expanded. One dump per Wiktionary language edition.
 
 ## Build & Test
 
-Requires Java 25 and Apache Maven. Produces a fat JAR via `maven-shade-plugin`.
+Requires Java 25 and Apache Maven.
 
 ```sh
-mvn package          # compiles, runs tests, produces fat JAR
-# Output: target/wiktionary-to-kindle-1.0.0.jar
+mvn package          # compiles, runs tests, produces the fat JAR
+mvn javafx:run       # runs the desktop app
+scripts/package.sh   # jlink + jpackage bundle for the host platform → target/dist
 ```
 
-JUnit 5 tests live in `src/test/java/edu/self/w2k/`.
+JUnit 5 tests live in `src/test/java/edu/self/w2k/`. `MainFxmlLoadTest` needs a graphics toolkit and self-skips without one; CI runs the suite under `xvfb-run`.
 
-## Running the JAR
+The version comes from `${project.version}` via a filtered `application.properties`, read through `AppVersion`. Resource filtering is scoped to that one file — filtering all of `src/main/resources` would corrupt `icon.png`.
 
-The entry point is `edu.self.w2k.CLI`. Commands:
+## Running the CLI
+
+The CLI entry point is `edu.self.w2k.CLI`; the GUI's is `edu.self.w2k.gui.Launcher`.
 
 ```sh
 # Download kaikki.org dump to dumps/ (skips if a dump for that lang already exists)
-java -jar target/wiktionary-to-kindle-1.0.0.jar download        # English (default)
-java -jar target/wiktionary-to-kindle-1.0.0.jar download fr     # French edition
+java -jar target/wiktionary-to-kindle-<version>.jar download        # English (default)
+java -jar target/wiktionary-to-kindle-<version>.jar download fr     # French edition
 # dl is a short alias for download
 
 # Generate Kindle dictionary from a downloaded dump.
 # DUMP_LANG = which Wiktionary edition to read; WORD_LANG = ISO 639-1 filter.
 # The latest dump matching DUMP_LANG in dumps/ is auto-discovered.
-java -jar target/wiktionary-to-kindle-1.0.0.jar generate <DUMP_LANG> <WORD_LANG>
-java -jar target/wiktionary-to-kindle-1.0.0.jar generate el en                        # auto-downloads kindling-cli on first run
-java -jar target/wiktionary-to-kindle-1.0.0.jar generate el en --kindling-version vX.Y.Z
-java -jar target/wiktionary-to-kindle-1.0.0.jar generate el en --kindling-cli /usr/local/bin/kindling-cli
+java -jar target/wiktionary-to-kindle-<version>.jar generate <DUMP_LANG> <WORD_LANG>
+java -jar target/wiktionary-to-kindle-<version>.jar generate el en --kindling-version vX.Y.Z
+java -jar target/wiktionary-to-kindle-<version>.jar generate el en --kindling-cli /usr/local/bin/kindling-cli
 # gen is a short alias for generate
 
-# Help / version
-java -jar target/wiktionary-to-kindle-1.0.0.jar --help
-java -jar target/wiktionary-to-kindle-1.0.0.jar --version
+java -jar target/wiktionary-to-kindle-<version>.jar --help
+java -jar target/wiktionary-to-kindle-<version>.jar --version
 ```
+
+`download` exits 1 when the transfer fails. The CLI keeps CWD-relative `dumps/` and `dictionaries/` and does **not** read the GUI's preferences.
 
 ## Architecture
 
 ### Package Structure
 
-- **`edu.self.w2k`** — `CLI` — picocli root command + inner `Download` / `Generate` subcommand wiring classes
-- **`edu.self.w2k.command`** — `DownloadCommand`, `GenerateCommand` — service orchestrators; `Command` interface
-- **`edu.self.w2k.download`** — `KaikkiDumpDownloader` (HttpClient-based), `DumpDownloader` interface
+- **`edu.self.w2k`** — `CLI` — picocli root command + inner `Download` / `Generate` subcommand wiring classes, and `BuildVersion` (reports the filtered build version)
+- **`edu.self.w2k.gui`** — JavaFX front-end. `Launcher` (plain `main`, **must not** extend `Application` — a classpath launch otherwise fails with "JavaFX runtime components are missing"), `App` (FXML load, appender install), `MainViewModel` (state and derivations; `javafx.base` only, so unit-testable without a toolkit), `MainController` (bindings only), `PipelineService`/`PipelineTask` (threading + cancellation), `UiLogAppender`, `ProgressSnapshot`, `PreferencesDialog`, `ByteSizes`, `LanguageConverter`. FXML and CSS in `src/main/resources/edu/self/w2k/gui/`
+- **`edu.self.w2k.pipeline`** — `DictionaryPipeline` — the combined download-then-generate flow, JavaFX-free and injectable so it stays testable
+- **`edu.self.w2k.progress`** — `ProgressListener` (`Stage`, `TOTAL_UNKNOWN`, `NOOP`), `CountingInputStream`. Progress is constructor-injected everywhere, so each collaborator keeps its pre-existing constructor arity
+- **`edu.self.w2k.config`** — `AppPaths` (config and data dirs), `Preferences` (properties file), `LanguageCatalog` (dropdown lists), `AppVersion`
+- **`edu.self.w2k.dump`** — `DumpCatalog`, `DumpFile` — lists/deletes dumps; `CLI.findLatestDump` delegates to `latestFor`
+- **`edu.self.w2k.command`** — `DownloadCommand`, `GenerateCommand` — service orchestrators; `Command` interface. Both expose an `execute()` returning the produced path alongside the interface's `void run()`
+- **`edu.self.w2k.download`** — `KaikkiDumpDownloader` (HttpClient-based), `DumpDownloader` interface, `DownloadResult`
 - **`edu.self.w2k.write`** — `DictionaryWriter` interface, `DictionaryTitles` utility
 - **`edu.self.w2k.write.opf`** — `OpfDictionaryWriter` (emits chunked `.html` + `.opf`), `HtmlChapterRenderer`
 - **`edu.self.w2k.kindling`** — `KindlingDictionaryConverter` (composes `OpfDictionaryWriter` + kindling binary), `KindlingCliResolver` (override → PATH → cache → download), `KindlingDownloader` (GitHub releases API + SHA-256 verify), `KindlingPlatform` enum, `KindlingRelease` (loads the pinned version + per-platform digests from `src/main/resources/kindling-release.properties`), `XdgCachePaths`, `KindlingException`
@@ -57,10 +72,17 @@ java -jar target/wiktionary-to-kindle-1.0.0.jar --version
 
 ### Data Directories
 
+The two front-ends resolve these differently, deliberately.
+
 | Directory | Purpose |
 |-----------|---------|
 | `dumps/`  | Downloaded `raw-wiktextract-data-{lang}-{YYYY-MM-DD}.jsonl.gz` from kaikki.org |
 | `dictionaries/` | Final `.mobi` dictionary files, plus side-artefacts `.opf` and `-N.html` |
+
+- **CLI**: CWD-relative, via the `CLI.DUMPS_DIR` / `CLI.DICTIONARIES_DIR` constants. Unchanged from before the GUI existed.
+- **GUI**: absolute, from `Preferences`, defaulting under `AppPaths.defaultDataDir()` (`~/Documents/wiktionary-to-kindle`). A bundled `.app` launches with `cwd=/`, so relative paths would resolve at the filesystem root — this is not a stylistic choice.
+
+`AppPaths.configDir()` holds `preferences.properties` and `logs/app.log`; `XdgCachePaths` holds the cached `kindling-cli`.
 
 ### Dictionary Output Format
 
@@ -88,9 +110,28 @@ Gloss and example text is XML-escaped with `StringEscapeUtils.escapeXml10`; inte
 ## Key Conventions
 
 - **CLI** uses [picocli](https://picocli.info/). `CLI.java` is the root `@Command`; `Download` and `Generate` are inner static subcommand classes that wire collaborators and delegate to the service-layer command classes.
-- **Service classes** (`DownloadCommand`, `GenerateCommand`) use Lombok `@RequiredArgsConstructor` and are independent of picocli — they can be constructed directly in tests.
-- **Logging** uses SLF4J 2.x with Logback Classic. `@Slf4j` (Lombok) is used on all classes.
+- **Service classes** (`DownloadCommand`, `GenerateCommand`) are independent of picocli and of JavaFX — they can be constructed directly in tests.
+- **Progress** flows through `ProgressListener`, constructor-injected with a `NOOP` default. Emissions are throttled (roughly every 4 MB); the dump is millions of lines, so per-item reporting would swamp any listener. Download progress needs `BodyHandlers.ofInputStream` plus a manual copy loop — `ofFile` offers neither a byte callback nor a cancellation point. Parse progress counts the *compressed* stream, since a gzip member's uncompressed size is unknowable up front.
+- **Cancellation** takes two mechanisms: interrupting the worker covers the download and parse loops, but the kindling stage blocks in `Process.waitFor()`, so `PipelineTask` tracks the process and destroys it in `cancelled()`.
+- **Logging** uses SLF4J 2.x with Logback Classic. `@Slf4j` (Lombok) is used on all classes. `logback.xml` configures the CLI console only; the GUI adds `UiLogAppender` and a file appender **programmatically**, so CLI output is untouched. `UiLogAppender` buffers into a bounded queue the UI drains in batches — never one `Platform.runLater` per event, which would freeze the window.
+- **Subprocesses**: `KindlingDictionaryConverter.defaultRunner()` pumps merged stdout/stderr through SLF4J. Do not switch it back to `inheritIO()` — a windowed app has no terminal, so the output would vanish.
 - **Jackson** is used for JSONL parsing. Model records carry `@JsonIgnoreProperties(ignoreUnknown = true)`. `ObjectMapper` is configured with `Nulls.AS_EMPTY` so missing collection fields default to empty lists. The `ObjectReader` is reused across all lines for efficiency.
 - **Parser streaming**: `JsonlDictionaryParser.parse()` returns a lazy `Stream<WiktionaryEntry>` backed by a `BufferedReader.lines()` pipeline. Callers must close the stream (use try-with-resources).
 - **Download** uses `java.net.http.HttpClient` and an atomic `.part` file rename to avoid corrupt downloads on failure. A HEAD request (30 s timeout) reads `last-modified` and `content-length` first, so the target filename and the skip-if-already-downloaded check resolve before any body transfer; the GET that follows carries a deliberately generous 6 h ceiling because dumps are multi-gigabyte (a request-level timeout bounds the *whole* exchange, not just the headers). URL is computed per lang: `en` → `/dictionary/`, others → `/{lang}wiktionary/`.
-- **Dump file path**: dumps are named `dumps/raw-wiktextract-data-{lang}-{YYYY-MM-DD}.jsonl.gz`. `generate` resolves the file via `CLI.findLatestDump(lang)`, which globs the dumps dir for that prefix and picks the lexicographically latest filename (ISO date format sorts correctly). If no dump matches, generate exits 1.
+- **Dump file path**: dumps are named `dumps/raw-wiktextract-data-{lang}-{YYYY-MM-DD}.jsonl.gz`. `generate` resolves the file via `CLI.findLatestDump(lang)` → `DumpCatalog.latestFor`, which globs the dumps dir for that prefix and picks the lexicographically latest filename (ISO date format sorts correctly). If no dump matches, generate exits 1. Discovery stays filename-based rather than going through `DumpFile.parse`, so a dump named `-unknown` (kaikki omitted `last-modified`) is still usable even though it cannot be listed in the dumps pane.
+
+## Packaging
+
+`scripts/package.sh` runs jlink then jpackage; one bash script covers all platforms, since Windows runners provide bash. Things that will bite if changed carelessly:
+
+- **The JDK module list** was computed with `jdeps --print-module-deps`, plus four modules static analysis cannot see: `jdk.crypto.ec` (without it every HTTPS request fails at handshake), `jdk.localedata` (without it language names degrade to bare uppercase codes), `java.logging` and `jdk.unsupported`. Both of the first two fail *silently*, which is why the script links a probe into the fresh image and runs it there.
+- **JavaFX is excluded from the shaded JAR** (`artifactSet` exclude in the shade config). JavaFX resolves to platform-classified native artifacts, so bundling it would tie the CLI JAR to whichever OS built it.
+- **Only classified JavaFX jars are real modules**; the unclassified ones are ~300-byte stubs that shadow them on the module path. The script selects by presence of `module-info.class`.
+- **`Launcher` must not extend `Application`** — see the `gui` package note above.
+- Use `$PATH_SEPARATOR`, not a literal `:`, in module paths and classpaths; Windows uses `;`.
+
+## CI & Release
+
+- `java-ci.yaml` — `build` runs `mvn verify` under `xvfb-run` on Ubuntu; `package` runs jlink+jpackage on macOS and Windows, so a packaging regression is caught in a PR rather than at release time.
+- `release.yml` — `workflow_dispatch` with a bump choice. Bumps via `maven-release-plugin` (hence the `-SNAPSHOT` version and `<scm>` block), builds the DMG, Scoop ZIP and portable JAR, publishes, then dispatches to `nyg/homebrew-tap` and pushes a manifest to `nyg/scoop-bucket`. `RELEASE_TOKEN` needs write access to all three repos.
+- Conventional commits; `git-cliff` generates the changelog from them via `cliff.toml`.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,96 @@
 # wiktionary-to-kindle
 
-Converts a set of Wiktionary entries into a MOBI dictionary usable by a Kindle.
+Turns Wiktionary into a MOBI dictionary your Kindle can use for tap-to-define — in any of a hundred-odd languages, for any Wiktionary edition [kaikki.org](https://kaikki.org) publishes.
+
+Available as a desktop app that bundles its own Java runtime, or as a command-line tool.
+
+## Install
+
+### macOS
+
+```sh
+brew install --cask nyg/tap/wiktionary-to-kindle
+```
+
+### Windows
+
+```powershell
+scoop bucket add nyg https://github.com/nyg/scoop-bucket
+scoop install wiktionary-to-kindle
+```
+
+Scoop installs per-user, needs no admin rights, and avoids the SmartScreen prompt.
+
+### Manual download
+
+Grab the [latest release](https://github.com/nyg/wiktionary-to-kindle/releases/latest):
+
+| File | For |
+|------|-----|
+| `WiktionaryToKindle.dmg` | macOS (Apple Silicon) |
+| `WiktionaryToKindle-Scoop.zip` | Windows — extract and run `Wiktionary to Kindle.exe` |
+| `wiktionary-to-kindle-*.jar` | Linux, or scripted use anywhere. Needs Java 25 |
+
+The app is ad-hoc signed but **not notarized**, so macOS quarantines the DMG download and blocks the first launch — you may see *"is damaged"* or *"Apple could not verify…"*, which both mean the same thing and do not mean the app is corrupted. Homebrew handles this for you. If you installed the DMG by hand, clear the flag once:
+
+```sh
+xattr -dr com.apple.quarantine "/Applications/Wiktionary to Kindle.app"
+```
+
+There is no Linux desktop package: Homebrew casks are macOS-only. Linux users can run the portable JAR, which needs Java 25 installed.
+
+## Using the app
+
+1. Pick a **Wiktionary edition** — which Wiktionary the definitions are written in. The Greek Wiktionary defines words in Greek.
+2. Pick a **word language** — which language's words to include. Any language may appear in any edition.
+3. Press **Build dictionary**.
+
+So *edition: Greek, word language: English* gives you an English–Greek dictionary: look up an English word, read the definition in Greek. The title updates as you choose, so you can see what you are about to build.
+
+The first build for an edition downloads its dump, which is 100 MB to several GB. Progress and a live log are shown throughout, and **Cancel** stops the run cleanly at any stage. Subsequent builds reuse the downloaded dump.
+
+When it finishes, **Show in folder** reveals the `.mobi`. Copy it to your Kindle over USB, or send it to your device's Kindle email address.
+
+The **Dumps** tab lists what has been downloaded, with dates and sizes, and lets you delete dumps you no longer need — worth checking, since they are the largest thing this app puts on your disk.
+
+### Where files go
+
+| What | Location |
+|------|----------|
+| Dumps and dictionaries | `~/Documents/wiktionary-to-kindle/` (change in Preferences) |
+| Settings and logs | `~/.config/wiktionary-to-kindle/` — `%LOCALAPPDATA%\wiktionary-to-kindle\Config` on Windows |
+| Cached `kindling-cli` | `~/.cache/wiktionary-to-kindle/` — `%LOCALAPPDATA%\wiktionary-to-kindle\Cache` on Windows |
+
+Preferences also lets you point at a pre-installed `kindling-cli` or pin a specific version. Maximum heap is shown there but cannot be changed: it is fixed when the app starts, and the bundle sizes it at 75% of your machine's RAM.
+
+## Command line
+
+The same pipeline, for scripting and for Linux. Every release ships a portable JAR that runs anywhere with Java 25.
+
+```sh
+# Download a dump to ./dumps (skipped if one for that edition already exists)
+java -jar wiktionary-to-kindle-2.0.0.jar download el
+
+# Generate into ./dictionaries
+# DUMP_LANG = which Wiktionary edition to read; WORD_LANG = ISO 639-1 filter
+java -jar wiktionary-to-kindle-2.0.0.jar generate el en
+
+# Pin a kindling release, or use one already installed
+java -jar wiktionary-to-kindle-2.0.0.jar generate el en --kindling-version vX.Y.Z
+java -jar wiktionary-to-kindle-2.0.0.jar generate el en --kindling-cli /usr/local/bin/kindling-cli
+
+java -jar wiktionary-to-kindle-2.0.0.jar --help
+```
+
+`dl` and `gen` are short aliases. The CLI resolves `dumps/` and `dictionaries/` relative to the working directory, and does not read the app's preferences. `download` exits non-zero if the transfer fails.
 
 ## How it works
 
-1. A [kaikki.org](https://kaikki.org) pre-extracted Wiktionary JSONL dump is downloaded for the desired language edition. Dumps are produced weekly by [wiktextract](https://github.com/tatuylonen/wiktextract) and include all languages with Lua templates fully expanded.
-2. The compressed JSONL is streamed and filtered by language. Each entry's senses are rendered into an HTML definition string, its inflected forms are collected as Kindle lookup targets, and the result is grouped in-memory by normalised key.
-3. Chunked MobiPocket HTML files and an OPF manifest are written to `dictionaries/`.
-4. On first run, [kindling-cli](https://github.com/ciscoriordan/kindling) is downloaded automatically and cached under `~/.cache/wiktionary-to-kindle/kindling/` (Linux/macOS) or `%LOCALAPPDATA%\wiktionary-to-kindle\Cache\kindling\` (Windows). The binary is SHA-256 verified before use.
-5. `kindling-cli build` converts the OPF to a `.mobi` Kindle dictionary in `dictionaries/`.
+1. A [kaikki.org](https://kaikki.org) pre-extracted Wiktionary JSONL dump is downloaded for the chosen edition. Dumps are produced weekly by [wiktextract](https://github.com/tatuylonen/wiktextract) and include all languages with Lua templates fully expanded.
+2. The compressed JSONL is streamed and filtered by language. Each entry's senses are rendered into an HTML definition, its inflected forms are collected as Kindle lookup targets, and the result is grouped in memory by normalised key.
+3. Chunked MobiPocket HTML files and an OPF manifest are written.
+4. On first run, [kindling-cli](https://github.com/ciscoriordan/kindling) is downloaded and cached, verified against a pinned SHA-256.
+5. `kindling-cli build` converts the OPF into a `.mobi` Kindle dictionary.
 
 ## Inflected forms
 
@@ -19,13 +101,38 @@ Wiktionary entries on kaikki include a `forms` array listing every inflected for
 
 Gender-equivalent cross-references (e.g. `συντρόφισσα` listed as a feminine equivalent of `σύντροφος`, or `ingénieure` listed under `ingénieur`) are filtered out of the **lookup index** by a language-agnostic post-pass: any form whose normalised text already exists as a standalone headword in the same dump is dropped from the iform list, so long-press on `συντρόφισσα` resolves to its own entry instead of being shadowed by the lemma. The **visible "Forms:" table** in each entry's HTML body is untouched — readers still see the full paradigm (e.g. `ingénieure`, `ingénieurs`) under the lemma.
 
-See [`docs/inflection-support.md`](docs/inflection-support.md) for the full design.
+See [`docs/form-of-folding.md`](docs/form-of-folding.md) for the full design.
 
 ## Examples of generated dictionaries
 
 * [English-English (96MB)](http://www.mediafire.com/file/uib98cjr19d0ddt/lexicon_en_en.mobi)
 * [French-English (27MB)](http://www.mediafire.com/file/c3v5aijgp4q5ge3/lexicon_fr_en.mobi)
 * [Greek-English (6MB)](http://www.mediafire.com/file/2nccw6ni32k4gmf/lexicon_gr_en.mobi)
+
+## Building from source
+
+Requires Java 25 and [Apache Maven](https://maven.apache.org).
+
+```sh
+mvn package        # runs tests, produces target/wiktionary-to-kindle-<version>.jar
+mvn javafx:run     # runs the desktop app
+```
+
+To build a native bundle for the host platform:
+
+```sh
+scripts/package.sh          # defaults per platform; pass dmg, app-image, msi or deb explicitly
+```
+
+It jlinks a trimmed runtime, verifies it — TLS, locale data, the JavaFX modules and `ImageIO` all have to resolve inside the fresh image, and packaging fails if any of them do not — then runs `jpackage`. Output lands in `target/dist`.
+
+Only the macOS `dmg` and Windows `app-image` targets are built in CI and shipped; the Linux `deb` target is a convenience for local use and is not exercised.
+
+The shaded JAR deliberately excludes JavaFX so it stays cross-platform: JavaFX resolves to native, platform-specific artifacts, and the desktop app gets them from its bundled runtime instead.
+
+## Releasing
+
+Run the **Release** workflow from the Actions tab and choose a bump. It tags the release, builds the DMG, the Scoop ZIP and the portable JAR, publishes them, then updates [nyg/homebrew-tap](https://github.com/nyg/homebrew-tap) and [nyg/scoop-bucket](https://github.com/nyg/scoop-bucket).
 
 ## Helpful documentation
 
@@ -35,65 +142,6 @@ See [`docs/inflection-support.md`](docs/inflection-support.md) for the full desi
 * [EPUB Dictionaries and Glossaries 1.0](http://idpf.org/epub/dict/)
 * [EPUB – Wikipedia](https://en.wikipedia.org/wiki/EPUB)
 * [Creating Dictionaries – Kindle Publishing Guidelines](https://kdp.amazon.com/en_US/help/topic/G2HXJS944GL88DNV)
-
-## How to generate your own dictionary
-
-### 1. Clone the repository
-
-```sh
-git clone https://github.com/nyg/wiktionary-to-kindle.git
-```
-
-### 2. Build the project
-
-[Apache Maven](https://maven.apache.org) and Java 25 are required.
-
-```sh
-mvn package
-```
-
-### 3. Download the kaikki.org dump
-
-Downloads `raw-wiktextract-data-{lang}-{YYYY-MM-DD}.jsonl.gz` (~1–2 GB compressed for English) from kaikki.org to `dumps/`. If a dump for that language already exists, the download is skipped. The default language is English (`en`).
-
-```sh
-# Download English edition (default)
-java -jar target/wiktionary-to-kindle-1.0.0.jar download
-
-# Download a specific edition (e.g. French)
-java -jar target/wiktionary-to-kindle-1.0.0.jar download fr
-
-# dl is a short alias for download
-java -jar target/wiktionary-to-kindle-1.0.0.jar dl fr
-
-# Show help
-java -jar target/wiktionary-to-kindle-1.0.0.jar --help
-java -jar target/wiktionary-to-kindle-1.0.0.jar download --help
-```
-
-### 4. Generate the dictionary
-
-Filter entries for the language of your choice using its [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1) code (e.g. `el` for Greek, `fr` for French, `de` for German). The dump is streamed and decompressed on the fly — no extra disk space needed.
-
-On first run, `kindling-cli` is downloaded automatically from GitHub Releases and cached under `~/.cache/wiktionary-to-kindle/kindling/` (Linux/macOS) or `%LOCALAPPDATA%\wiktionary-to-kindle\Cache\kindling\` (Windows). Subsequent runs use the cached binary.
-
-```sh
-# Produces dictionaries/dictionary-el-en.mobi (plus .opf and .html side-artefacts)
-java -jar target/wiktionary-to-kindle-1.0.0.jar generate el en
-
-# Pin a specific kindling release (run `generate --help` to see the default)
-java -jar target/wiktionary-to-kindle-1.0.0.jar generate el en --kindling-version vX.Y.Z
-
-# Use a pre-installed kindling-cli binary (skips download)
-java -jar target/wiktionary-to-kindle-1.0.0.jar generate el en --kindling-cli /usr/local/bin/kindling-cli
-
-# Show help
-java -jar target/wiktionary-to-kindle-1.0.0.jar generate --help
-```
-
-### 5. Upload the file to your Kindle
-
-Send `dictionaries/dictionary-el-en.mobi` to your device via its Kindle email address, or drag and drop it as you would with any eBook.
 
 ## Screenshots
 


### PR DESCRIPTION
Phase 6 — the last of the desktop-app work (follows #65, #66, #67, #70, #71).

The README still told people to clone the repo, install Java and Maven, and run `mvn package`. That's now the *fallback* path, not the main one.

## README

Leads with `brew` and `scoop`. Beyond the install commands, it does three things the old one couldn't:

- **Explains the two language pickers.** The edition/word-language distinction is the one genuinely confusing thing about this tool, so it gets a worked example: *edition Greek + word language English* → an English–Greek dictionary, i.e. look up an English word, read the definition in Greek.
- **Documents where files actually go** — dumps and dictionaries under `~/Documents/wiktionary-to-kindle`, settings and logs under `~/.config`, cache separately, with the Windows equivalents.
- **States the quarantine behaviour plainly**, including that *"is damaged"* does not mean the download is corrupt — that message is alarming and the explanation belongs where people will look for it.

It also says what the tool *doesn't* do: no Linux desktop package (Homebrew casks are macOS-only), and the Linux `deb` target of `package.sh` is a local convenience CI never builds. I'd rather state that than let someone discover it.

## Drive-by fix

The old README linked `docs/inflection-support.md`, **which does not exist**. Now points at `docs/form-of-folding.md`, which does. Verified every relative link in both files resolves.

## `.github/copilot-instructions.md`

This is the target of the `CLAUDE.md` symlink, and it still described a CLI-only architecture — actively misleading for future work on this repo. Now covers the `gui`, `pipeline`, `progress`, `config` and `dump` packages, and records the decisions that look arbitrary but aren't:

- why `Launcher` must not extend `Application`
- why JavaFX is excluded from the shaded JAR
- why only *classified* JavaFX jars are real modules
- why the module list carries `jdk.crypto.ec` and `jdk.localedata` (both fail silently)
- why the appenders are installed programmatically
- why `defaultRunner()` must not go back to `inheritIO()`
- why the CLI keeps CWD-relative paths while the GUI cannot

## Verification

224 tests pass. All relative links in both files checked to resolve. `CLAUDE.md` symlink intact — edited the target, not the link.

## Not included

**No screenshot of the app.** The README has a natural place for one, but I'd be inventing an image reference I can't produce. Worth adding a real one before the first release, since the install sections are otherwise text-only.

The CLI examples reference `2.0.0`, matching the first release the #71 workflow will cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)