### PR TITLE
ci: use conventional commit messages for release commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,16 +99,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      # Committed before release:prepare so the changelog is part of the tagged tree rather than
-      # landing a commit after it.
-      - name: Update changelog
-        run: |
-          git cliff --tag "v${{ env.RELEASE_VERSION }}" -o CHANGELOG.md
-          git add CHANGELOG.md
-          git commit -m "chore(release): update changelog for v${{ env.RELEASE_VERSION }}"
-
-      # Runs the full test suite as part of its own verification. Xvfb is needed for the FXML load
-      # test, exactly as in java-ci.
+      # Runs the full test suite as part of its own verification, then scripts/generate-changelog.sh
+      # (exec:exec in preparationGoals), which stages CHANGELOG.md into the tagged commit. Xvfb is
+      # needed for the FXML load test, exactly as in java-ci.
       - name: Install Xvfb
         run: sudo apt-get update && sudo apt-get install -y xvfb
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -62,6 +62,8 @@ commit_parsers = [
     { message = "^perf", group = "<!-- 5 -->⚡ Performance" },
     { message = "^style", group = "<!-- 6 -->🎨 Styling" },
     { message = "^test", group = "<!-- 7 -->🧪 Testing" },
+    # Legacy release commits, from before scmCommentPrefix was set on maven-release-plugin.
+    { message = "^\\[maven-release-plugin\\]", skip = true },
     { message = "^chore\\(release\\):", skip = true },
     { message = "^(chore|ci|build)", group = "<!-- 8 -->⚙️ Miscellaneous" },
     { message = "^revert", group = "<!-- 9 -->◀️ Revert" },

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
         <sonar-maven-plugin.version>5.7.0.6970</sonar-maven-plugin.version>
         <javafx-maven-plugin.version>0.0.8</javafx-maven-plugin.version>
         <maven-release-plugin.version>3.3.1</maven-release-plugin.version>
+        <exec-maven-plugin.version>3.6.3</exec-maven-plugin.version>
 
         <!-- SonarCloud -->
         <sonar.organization>nyg</sonar.organization>
@@ -205,6 +206,17 @@
                 </configuration>
             </plugin>
 
+            <!-- Runs scripts/generate-changelog.sh, invoked as exec:exec from the release
+                 plugin's preparationGoals below. -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>${exec-maven-plugin.version}</version>
+                <configuration>
+                    <executable>./scripts/generate-changelog.sh</executable>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
@@ -212,6 +224,12 @@
                 <configuration>
                     <tagNameFormat>v@{project.version}</tagNameFormat>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <!-- exec:exec regenerates and stages CHANGELOG.md, so it lands in the
+                         tagged "prepare release" commit rather than a separate one. -->
+                    <preparationGoals>clean verify exec:exec</preparationGoals>
+                    <!-- @formatter:off -->
+                    <scmCommentPrefix>chore(release): </scmCommentPrefix>
+                    <!-- @formatter:on -->
                 </configuration>
             </plugin>
 

--- a/scripts/generate-changelog.sh
+++ b/scripts/generate-changelog.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+set -e
+
+# Run by release:prepare via preparationGoals (exec:exec), after release.properties has been
+# written and before the release plugin commits. Staging CHANGELOG.md here puts it in the
+# tagged "chore(release): prepare release vX.Y.Z" commit rather than a separate commit.
+VERSION=$(grep scm.tag= release.properties | awk -Fv '{print $2}')
+echo "Generating changelog for version $VERSION"
+
+git cliff --tag "v$VERSION" -o CHANGELOG.md
+git add CHANGELOG.md


### PR DESCRIPTION
## Problem

Releases produced three commits, two of them non-conventional:

```
[maven-release-plugin] prepare for next development iteration
[maven-release-plugin] prepare release v2.0.2
chore(release): update changelog for v2.0.2
```

`cliff.toml` already skips `^chore\(release\):`, but the default
`maven-release-plugin` prefix never matched it, so release plumbing leaked into
`CHANGELOG.md` under an **Others** heading (4 such lines today). The changelog
also landed in its own commit *before* the tagged one.

`kraken-api-java` and `jmxsh` already do this the wanted way:

```
chore(release): prepare for next development iteration
chore(release): prepare release v3.0.1     ← contains pom.xml + CHANGELOG.md
```

## Changes

- **`pom.xml`** — `<scmCommentPrefix>chore(release): </scmCommentPrefix>` and
  `<preparationGoals>clean verify exec:exec</preparationGoals>` on
  `maven-release-plugin`; `exec-maven-plugin` added to run the changelog script.
  No `<executions>` binding, so `mvn package` and the packaging jobs are untouched.
- **`scripts/generate-changelog.sh`** (new) — reads the version from
  `release.properties`, runs `git cliff --tag`, stages `CHANGELOG.md`. maven-scm's
  git provider commits the index without a pathspec, so the staged changelog rides
  along in the tagged commit.
- **`.github/workflows/release.yml`** — the separate `Update changelog` step is gone;
  `Install git-cliff` stays, since `release:prepare` now needs it on PATH.
- **`cliff.toml`** — skip `^\[maven-release-plugin\]` so the six legacy commits stop
  rendering in regenerated changelogs.

`jmxsh` was checked and needs no change — it already has all of the above.

## Verification

`mvn release:prepare -DdryRun=true -DreleaseVersion=2.0.3` → BUILD SUCCESS, with:

```
--- exec:3.6.3:exec (default-cli) ---
Generating changelog for version 2.0.3
...
Full run would commit 1 files with message: 'chore(release): prepare release v2.0.3'
Full run would commit 1 files with message: 'chore(release): prepare for next development iteration'
```

`CHANGELOG.md` was staged with a new `## [2.0.3]` section and zero
`[maven-release-plugin]` lines anywhere in the file (10 lines removed). Dry-run
artefacts cleaned with `release:clean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)