### PR TITLE
Fix Wiktionary edition and language selection

### DIFF
--- a/src/main/java/edu/self/w2k/config/LanguageCatalog.java
+++ b/src/main/java/edu/self/w2k/config/LanguageCatalog.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.Properties;
 
 import edu.self.w2k.write.DictionaryTitles;
@@ -91,5 +92,13 @@ public final class LanguageCatalog {
                 .map(Language::of)
                 .sorted(Comparator.naturalOrder())
                 .toList();
+    }
+
+    public static Optional<Language> findEdition(String input) {
+        return editions().stream()
+            .filter(language -> 
+                language.code().equalsIgnoreCase(input)
+                || language.displayName().equalsIgnoreCase(input)
+            ).findFirst();
     }
 }

--- a/src/main/java/edu/self/w2k/gui/LanguageConverter.java
+++ b/src/main/java/edu/self/w2k/gui/LanguageConverter.java
@@ -1,5 +1,6 @@
 package edu.self.w2k.gui;
 
+import edu.self.w2k.config.LanguageCatalog;
 import edu.self.w2k.config.LanguageCatalog.Language;
 import javafx.util.StringConverter;
 
@@ -27,6 +28,6 @@ public class LanguageConverter extends StringConverter<Language> {
         String code = open >= 0 && close > open
                 ? trimmed.substring(open + 1, close).strip()
                 : trimmed;
-        return code.isEmpty() ? null : Language.of(code);
+        return LanguageCatalog.findEdition(code).orElseGet(() -> Language.of(code));
     }
 }

--- a/src/main/java/edu/self/w2k/gui/LanguageConverter.java
+++ b/src/main/java/edu/self/w2k/gui/LanguageConverter.java
@@ -28,6 +28,11 @@ public class LanguageConverter extends StringConverter<Language> {
         String code = open >= 0 && close > open
                 ? trimmed.substring(open + 1, close).strip()
                 : trimmed;
+
+        if (code.isBlank()) {
+            return null;
+        }
+        
         return LanguageCatalog.findEdition(code).orElseGet(() -> Language.of(code));
     }
 }

--- a/src/test/java/edu/self/w2k/config/LanguageCatalogTest.java
+++ b/src/test/java/edu/self/w2k/config/LanguageCatalogTest.java
@@ -3,6 +3,8 @@ package edu.self.w2k.config;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import edu.self.w2k.config.LanguageCatalog.Language;
+import edu.self.w2k.gui.LanguageConverter;
+
 import org.junit.jupiter.api.Test;
 
 class LanguageCatalogTest {
@@ -84,5 +86,28 @@ class LanguageCatalogTest {
         // When / Then
         assertThat(LanguageCatalog.parseCodes(null)).isEmpty();
         assertThat(LanguageCatalog.parseCodes("   ")).isEmpty();
+    }
+
+    @Test
+    void should_resolve_edition_by_display_name() {
+        // When
+        var edition = LanguageCatalog.findEdition("english");
+
+        // Then 
+        assertThat(edition).isNotNull();
+        assertThat(edition).isPresent().get().extracting(Language::code).isEqualTo("en");
+    }
+
+    @Test
+    void should_keep_unknown_edition() {
+        // Given
+        var input = "Not listed language";
+
+        // When
+        var result = new LanguageConverter().fromString(input);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.code()).isEqualTo(input);
     }
 }


### PR DESCRIPTION
This PR fixes an "issue" with Wiktionary edition names when converting the selected value back to a `Language`.

The issue occurs because the display name of an edition and its language code are different, and the display name could be incorrectly used when building the download URL.

### Changes

* Added `LanguageCatalog.findEdition(String input)` to resolve Wiktionary editions by either their language code or display name, case-insensitively.
* Updated `LanguageConverter.fromString()` to use the new edition lookup.
* Added an explicit check for blank language codes, returning `null` when no valid code is available. This was added to fix the test suite after the previous change.
* Added a test to ensure that editions not listed in `LanguageCatalog` can still be entered manually and are preserved.

### The reason

When I was trying to use the program, selecting English resulted in:

`ENGLISH (english)`

The value `english` was then used as the Wiktionary edition when building the URL in `KaikkiDumpDownloader.java`.

This resulted in the program trying to download:

`https://kaikki.org/englishwikitionary/row-wiktextract-data.jsonl.gz`

which caused an HTTP 404 exception.

The expected Wiktionary edition is `en`, so the generated URL should use the corresponding language code instead.

### Before

The selected edition was displayed as:

`ENGLISH (english)`

The value `english` was then used to build the download URL, resulting in the 404 error described above.

<img width="883" height="944" alt="image" src="https://github.com/user-attachments/assets/65fec936-24b9-4f93-8f87-dfb6a45f6246" />

### After

The edition is now resolved to its corresponding Wiktionary language code when it exists in `LanguageCatalog`.

For example, selecting English is now resolved to:

`en`

<img width="734" height="308" alt="image" src="https://github.com/user-attachments/assets/c5042d70-2944-4d6c-b466-a23d44a850c4" />

The application automatically uses the corresponding Wiktionary edition:

<img width="717" height="203" alt="image" src="https://github.com/user-attachments/assets/0376cb92-aec6-4c78-a2ae-2d900ffaa411" />

If the edition is not listed in `LanguageCatalog`, the manually entered value is preserved. This keeps the existing behavior that allows users to enter Wiktionary editions added after the application was built.

### Tests

Added test coverage for the new edition resolution behavior, including the case where an edition is not listed in `LanguageCatalog`.

The full test suite passes with:

`mvn clean test`

### Related commits

* `fix: normalize Wiktionary edition names`
* `fix: return null for empty language codes` (fixes the test suite affected by the previous commit)
* `test: cover Wiktionary edition resolution`
