### PR TITLE
feat(cli)!: share the desktop app's data folders

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,15 +32,17 @@ The version comes from `${project.version}` via a filtered `application.properti
 The CLI entry point is `edu.self.w2k.CLI`; the GUI's is `edu.self.w2k.gui.Launcher`.
 
 ```sh
-# Download kaikki.org dump to dumps/ (skips if a dump for that lang already exists)
+# Download kaikki.org dump to the dumps folder (skips if a dump for that lang already exists)
 java -jar target/wiktionary-to-kindle-<version>.jar download        # English (default)
 java -jar target/wiktionary-to-kindle-<version>.jar download fr     # French edition
+java -jar target/wiktionary-to-kindle-<version>.jar download fr --dumps-dir ./dumps
 # dl is a short alias for download
 
 # Generate Kindle dictionary from a downloaded dump.
 # DUMP_LANG = which Wiktionary edition to read; WORD_LANG = ISO 639-1 filter.
-# The latest dump matching DUMP_LANG in dumps/ is auto-discovered.
+# The latest dump matching DUMP_LANG in the dumps folder is auto-discovered.
 java -jar target/wiktionary-to-kindle-<version>.jar generate <DUMP_LANG> <WORD_LANG>
+java -jar target/wiktionary-to-kindle-<version>.jar generate el en --dumps-dir ./dumps --dictionaries-dir ./dictionaries
 java -jar target/wiktionary-to-kindle-<version>.jar generate el en --kindling-version vX.Y.Z
 java -jar target/wiktionary-to-kindle-<version>.jar generate el en --kindling-cli /usr/local/bin/kindling-cli
 # gen is a short alias for generate
@@ -49,7 +51,7 @@ java -jar target/wiktionary-to-kindle-<version>.jar --help
 java -jar target/wiktionary-to-kindle-<version>.jar --version
 ```
 
-`download` exits 1 when the transfer fails. The CLI keeps CWD-relative `dumps/` and `dictionaries/` and does **not** read the GUI's preferences.
+`download` exits 1 when the transfer fails. The CLI reads the **same** `preferences.properties` as the GUI, so both front-ends share one dumps folder and one dictionaries folder; `--dumps-dir` / `--dictionaries-dir` override it per invocation.
 
 ## Architecture
 
@@ -79,8 +81,9 @@ The two front-ends resolve these differently, deliberately.
 | `dumps/`  | Downloaded `raw-wiktextract-data-{lang}-{YYYY-MM-DD}.jsonl.gz` from kaikki.org |
 | `dictionaries/` | Final `.mobi` dictionary files, plus side-artefacts `.opf`, `-N.html`, `-toc.ncx` and `-cover.jpg` |
 
-- **CLI**: CWD-relative, via the `CLI.DUMPS_DIR` / `CLI.DICTIONARIES_DIR` constants. Unchanged from before the GUI existed.
-- **GUI**: absolute, from `Preferences`, defaulting under `AppPaths.defaultDataDir()` (`~/Documents/wiktionary-to-kindle`). A bundled `.app` launches with `cwd=/`, so relative paths would resolve at the filesystem root — this is not a stylistic choice.
+Both front-ends resolve them the same way: absolute, from `Preferences`, defaulting under `AppPaths.defaultDataDir()` (`~/Documents/wiktionary-to-kindle`). A bundled `.app` launches with `cwd=/`, so relative paths would resolve at the filesystem root — this is not a stylistic choice.
+
+The CLI additionally accepts `--dumps-dir` and `--dictionaries-dir`, overriding the preferences for that invocation. `CLI.Download.dumpsDir(Preferences)` and the matching pair on `CLI.Generate` are the single resolution point, and take the loaded preferences as an argument so they stay testable without touching the real config file. Up to 2.0.3 the CLI was CWD-relative via `CLI.DUMPS_DIR` / `CLI.DICTIONARIES_DIR` and never read preferences; both constants are gone, as is the `KaikkiDumpDownloader(String)` constructor that hardcoded `Path.of("dumps")`.
 
 `AppPaths` resolves four roles, all named `AppInfo.SLUG`. Unix-likes — **macOS included** — follow the XDG Base Directory spec; Windows gets sibling directories under `%LOCALAPPDATA%\wiktionary-to-kindle\`:
 
@@ -131,7 +134,7 @@ Gloss and example text is XML-escaped with `StringEscapeUtils.escapeXml10`; inte
 - **Jackson** is used for JSONL parsing. Model records carry `@JsonIgnoreProperties(ignoreUnknown = true)`. `ObjectMapper` is configured with `Nulls.AS_EMPTY` so missing collection fields default to empty lists. The `ObjectReader` is reused across all lines for efficiency.
 - **Parser streaming**: `JsonlDictionaryParser.parse()` returns a lazy `Stream<WiktionaryEntry>` backed by a `BufferedReader.lines()` pipeline. Callers must close the stream (use try-with-resources).
 - **Download** uses `java.net.http.HttpClient` and an atomic `.part` file rename to avoid corrupt downloads on failure. A HEAD request (30 s timeout) reads `last-modified` and `content-length` first, so the target filename and the skip-if-already-downloaded check resolve before any body transfer; the GET that follows carries a deliberately generous 6 h ceiling because dumps are multi-gigabyte (a request-level timeout bounds the *whole* exchange, not just the headers). URL is computed per lang: `en` → `/dictionary/`, others → `/{lang}wiktionary/`.
-- **Dump file path**: dumps are named `dumps/raw-wiktextract-data-{lang}-{YYYY-MM-DD}.jsonl.gz`. `generate` resolves the file via `CLI.findLatestDump(lang)` → `DumpCatalog.latestFor`, which globs the dumps dir for that prefix and picks the lexicographically latest filename (ISO date format sorts correctly). If no dump matches, generate exits 1. Discovery stays filename-based rather than going through `DumpFile.parse`, so a dump named `-unknown` (kaikki omitted `last-modified`) is still usable even though it cannot be listed in the dumps pane.
+- **Dump file path**: dumps are named `dumps/raw-wiktextract-data-{lang}-{YYYY-MM-DD}.jsonl.gz`. `generate` resolves the file via `CLI.findLatestDump(lang, dumpsDir)` → `DumpCatalog.latestFor`, which globs the dumps dir for that prefix and picks the lexicographically latest filename (ISO date format sorts correctly). If no dump matches, generate exits 1. Discovery stays filename-based rather than going through `DumpFile.parse`, so a dump named `-unknown` (kaikki omitted `last-modified`) is still usable even though it cannot be listed in the dumps pane.
 
 ## Packaging
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Once the `.mobi` is on the device, set it as the default dictionary for its lang
 
 | What | Location |
 |------|----------|
-| Dumps and dictionaries | `~/Documents/wiktionary-to-kindle/` (change in Preferences) |
+| Dumps and dictionaries | `~/Documents/wiktionary-to-kindle/` (change in Preferences; the CLI uses the same folders) |
 | Settings | `~/.config/wiktionary-to-kindle/` — `%LOCALAPPDATA%\wiktionary-to-kindle\Config` on Windows |
 | Log file | `~/.local/state/wiktionary-to-kindle/logs/app.log` — `%LOCALAPPDATA%\wiktionary-to-kindle\State` on Windows |
 | Cached `kindling-cli` | `~/.cache/wiktionary-to-kindle/` — `%LOCALAPPDATA%\wiktionary-to-kindle\Cache` on Windows |
@@ -87,12 +87,16 @@ Preferences also lets you point at a pre-installed `kindling-cli` or pin a speci
 The same pipeline, for scripting and for Linux. Every release ships a portable JAR that runs anywhere with Java 25.
 
 ```sh
-# Download a dump to ./dumps (skipped if one for that edition already exists)
+# Download a dump to the dumps folder (skipped if one for that edition already exists)
 java -jar wiktionary-to-kindle-<version>.jar download el
 
-# Generate into ./dictionaries
+# Generate into the dictionaries folder
 # DUMP_LANG = which Wiktionary edition to read; WORD_LANG = ISO 639-1 filter
 java -jar wiktionary-to-kindle-<version>.jar generate el en
+
+# Read from and write to somewhere else, for one invocation
+java -jar wiktionary-to-kindle-<version>.jar download el --dumps-dir ./dumps
+java -jar wiktionary-to-kindle-<version>.jar generate el en --dumps-dir ./dumps --dictionaries-dir ./dictionaries
 
 # Pin a kindling release, or use one already installed
 java -jar wiktionary-to-kindle-<version>.jar generate el en --kindling-version vX.Y.Z
@@ -102,7 +106,9 @@ java -jar wiktionary-to-kindle-<version>.jar --help
 java -jar wiktionary-to-kindle-<version>.jar --version
 ```
 
-`dl` and `gen` are short aliases. The CLI resolves `dumps/` and `dictionaries/` relative to the working directory, and does not read the app's preferences. `download` exits non-zero if the transfer fails.
+`dl` and `gen` are short aliases. The CLI reads the same preferences file as the desktop app, so both front-ends share one dumps folder and one dictionaries folder: download in the app and generate from the command line, or the reverse, and the dump is found either way. `--dumps-dir` and `--dictionaries-dir` override that per invocation, for scripts that want their own working folders. `download` exits non-zero if the transfer fails.
+
+Up to and including 2.0.3 the CLI resolved `dumps/` and `dictionaries/` relative to the working directory and ignored the app's preferences. To keep that behaviour, pass `--dumps-dir ./dumps --dictionaries-dir ./dictionaries`, or move the existing folders into `~/Documents/wiktionary-to-kindle/`.
 
 ## How it works
 

--- a/src/main/java/edu/self/w2k/CLI.java
+++ b/src/main/java/edu/self/w2k/CLI.java
@@ -9,6 +9,7 @@ import edu.self.w2k.command.DownloadCommand;
 import edu.self.w2k.command.GenerateCommand;
 import edu.self.w2k.config.AppInfo;
 import edu.self.w2k.config.AppVersion;
+import edu.self.w2k.config.Preferences;
 import edu.self.w2k.download.KaikkiDumpDownloader;
 import edu.self.w2k.dump.DumpCatalog;
 import edu.self.w2k.kindling.KindlingCliResolver;
@@ -16,6 +17,7 @@ import edu.self.w2k.kindling.KindlingDictionaryConverter;
 import edu.self.w2k.kindling.KindlingDownloader;
 import edu.self.w2k.kindling.KindlingRelease;
 import edu.self.w2k.parse.JsonlDictionaryParser;
+import edu.self.w2k.progress.ProgressListener;
 import edu.self.w2k.render.HtmlDefinitionRenderer;
 import edu.self.w2k.write.DictionaryTitles;
 import edu.self.w2k.write.DictionaryWriter;
@@ -36,8 +38,8 @@ import picocli.CommandLine.Spec;
          subcommands = {CLI.Download.class, CLI.Generate.class, CommandLine.HelpCommand.class})
 public class CLI implements Callable<Integer> {
 
-    static final Path DICTIONARIES_DIR = Path.of("dictionaries");
-    static final Path DUMPS_DIR = Path.of("dumps");
+    private static final String DUMPS_DIR_DESCRIPTION =
+            "Directory holding the kaikki.org dumps (default: the dumps folder from the app's preferences)";
 
     /**
      * Reports the version Maven filtered into the build, rather than a literal in this annotation
@@ -58,8 +60,8 @@ public class CLI implements Callable<Integer> {
         System.exit(new CommandLine(new CLI()).execute(args));
     }
 
-    static Optional<Path> findLatestDump(String lang) {
-        return new DumpCatalog(DUMPS_DIR).latestFor(lang);
+    static Optional<Path> findLatestDump(String lang, Path dumpsDir) {
+        return new DumpCatalog(dumpsDir).latestFor(lang);
     }
 
     @Override
@@ -80,16 +82,24 @@ public class CLI implements Callable<Integer> {
                     description = "Wiktionary edition language code (ISO 639-1, default: ${DEFAULT-VALUE})")
         private String lang;
 
+        @Option(names = "--dumps-dir", paramLabel = "DIR", description = DUMPS_DIR_DESCRIPTION)
+        private Path dumpsDir;
+
         @Override
         public Integer call() {
             try {
-                new DownloadCommand(new KaikkiDumpDownloader(lang)).run();
+                Path dumps = dumpsDir(Preferences.load());
+                new DownloadCommand(new KaikkiDumpDownloader(lang, dumps, ProgressListener.NOOP)).run();
                 return 0;
             }
             catch (IOException e) {
                 log.error("Download failed: {}", e.getLocalizedMessage());
                 return 1;
             }
+        }
+
+        Path dumpsDir(Preferences preferences) {
+            return dumpsDir != null ? dumpsDir : preferences.dumpsDir();
         }
     }
 
@@ -110,6 +120,15 @@ public class CLI implements Callable<Integer> {
                     arity = "1",
                     description = "Language to filter entries by (ISO 639-1)")
         private String wordLang;
+
+        @Option(names = "--dumps-dir", paramLabel = "DIR", description = DUMPS_DIR_DESCRIPTION)
+        private Path dumpsDir;
+
+        @Option(names = "--dictionaries-dir",
+                paramLabel = "DIR",
+                description = "Directory to write the dictionary into "
+                        + "(default: the dictionaries folder from the app's preferences)")
+        private Path dictionariesDir;
 
         @Option(names = "--kindling-cli",
                 description = "Path to a pre-installed kindling-cli binary. Skips download.")
@@ -133,9 +152,12 @@ public class CLI implements Callable<Integer> {
 
         @Override
         public Integer call() throws Exception {
-            Optional<Path> dumpFile = findLatestDump(dumpLang);
+            Preferences preferences = Preferences.load();
+            Path dumps = dumpsDir(preferences);
+
+            Optional<Path> dumpFile = findLatestDump(dumpLang, dumps);
             if (dumpFile.isEmpty()) {
-                log.error("No dump found for language {} in {}", dumpLang, DUMPS_DIR);
+                log.error("No dump found for language {} in {}", dumpLang, dumps);
                 return 1;
             }
 
@@ -151,10 +173,18 @@ public class CLI implements Callable<Integer> {
                     new HtmlDefinitionRenderer(),
                     writer,
                     dumpFile.get(),
-                    DICTIONARIES_DIR,
+                    dictionariesDir(preferences),
                     wordLang, dumpLang, title
             ).run();
             return 0;
+        }
+
+        Path dumpsDir(Preferences preferences) {
+            return dumpsDir != null ? dumpsDir : preferences.dumpsDir();
+        }
+
+        Path dictionariesDir(Preferences preferences) {
+            return dictionariesDir != null ? dictionariesDir : preferences.dictionariesDir();
         }
     }
 }

--- a/src/main/java/edu/self/w2k/CLI.java
+++ b/src/main/java/edu/self/w2k/CLI.java
@@ -10,6 +10,7 @@ import edu.self.w2k.command.GenerateCommand;
 import edu.self.w2k.config.AppInfo;
 import edu.self.w2k.config.AppVersion;
 import edu.self.w2k.config.Preferences;
+import edu.self.w2k.download.DumpDownloader;
 import edu.self.w2k.download.KaikkiDumpDownloader;
 import edu.self.w2k.dump.DumpCatalog;
 import edu.self.w2k.kindling.KindlingCliResolver;
@@ -17,6 +18,8 @@ import edu.self.w2k.kindling.KindlingDictionaryConverter;
 import edu.self.w2k.kindling.KindlingDownloader;
 import edu.self.w2k.kindling.KindlingRelease;
 import edu.self.w2k.parse.JsonlDictionaryParser;
+import edu.self.w2k.pipeline.DictionaryPipeline;
+import edu.self.w2k.pipeline.DictionaryPipeline.DownloaderFactory;
 import edu.self.w2k.progress.ProgressListener;
 import edu.self.w2k.render.HtmlDefinitionRenderer;
 import edu.self.w2k.write.DictionaryTitles;
@@ -85,11 +88,21 @@ public class CLI implements Callable<Integer> {
         @Option(names = "--dumps-dir", paramLabel = "DIR", description = DUMPS_DIR_DESCRIPTION)
         private Path dumpsDir;
 
+        /**
+         * Injectable so tests can drive {@link #call()} without the real downloader reaching
+         * kaikki.org, the same seam {@link DictionaryPipeline} uses.
+         */
+        DownloaderFactory downloaderFactory = KaikkiDumpDownloader::new;
+
         @Override
         public Integer call() {
+            Path dumps = dumpsDir(Preferences.load());
+            return run(downloaderFactory.create(lang, dumps, ProgressListener.NOOP));
+        }
+
+        int run(DumpDownloader downloader) {
             try {
-                Path dumps = dumpsDir(Preferences.load());
-                new DownloadCommand(new KaikkiDumpDownloader(lang, dumps, ProgressListener.NOOP)).run();
+                new DownloadCommand(downloader).run();
                 return 0;
             }
             catch (IOException e) {
@@ -154,6 +167,7 @@ public class CLI implements Callable<Integer> {
         public Integer call() throws Exception {
             Preferences preferences = Preferences.load();
             Path dumps = dumpsDir(preferences);
+            Path dictionaries = dictionariesDir(preferences);
 
             Optional<Path> dumpFile = findLatestDump(dumpLang, dumps);
             if (dumpFile.isEmpty()) {
@@ -173,7 +187,7 @@ public class CLI implements Callable<Integer> {
                     new HtmlDefinitionRenderer(),
                     writer,
                     dumpFile.get(),
-                    dictionariesDir(preferences),
+                    dictionaries,
                     wordLang, dumpLang, title
             ).run();
             return 0;

--- a/src/main/java/edu/self/w2k/download/KaikkiDumpDownloader.java
+++ b/src/main/java/edu/self/w2k/download/KaikkiDumpDownloader.java
@@ -46,10 +46,6 @@ public class KaikkiDumpDownloader implements DumpDownloader {
     private final Path dumpsDir;
     private final ProgressListener progress;
 
-    public KaikkiDumpDownloader(String lang) {
-        this(lang, Path.of("dumps"), ProgressListener.NOOP);
-    }
-
     public KaikkiDumpDownloader(String lang, Path dumpsDir, ProgressListener progress) {
         this(lang, defaultHttpClient(), dumpsDir, progress);
     }

--- a/src/test/java/edu/self/w2k/CLITest.java
+++ b/src/test/java/edu/self/w2k/CLITest.java
@@ -1,19 +1,34 @@
 package edu.self.w2k;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
 
 import edu.self.w2k.config.Preferences;
+import edu.self.w2k.download.DumpDownloader;
+import edu.self.w2k.pipeline.DictionaryPipeline;
+import edu.self.w2k.progress.ProgressListener;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import picocli.CommandLine;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class CLITest {
+
+    @Mock
+    private DumpDownloader downloader;
+
+    @Mock
+    private DictionaryPipeline.DownloaderFactory downloaderFactory;
 
     @Test
     void should_report_the_build_version_when_version_is_requested() {
@@ -144,5 +159,75 @@ class CLITest {
         // When / Then
         assertThat(unit.dumpsDir(preferences)).isEqualTo(Path.of("/override/dumps"));
         assertThat(unit.dictionariesDir(preferences)).isEqualTo(Path.of("/override/dictionaries"));
+    }
+
+    @Test
+    void should_pick_the_most_recent_dump_when_the_language_has_several(@TempDir Path dumpsDir) throws IOException {
+        // Given
+        Files.createFile(dumpsDir.resolve("raw-wiktextract-data-el-2026-01-09.jsonl.gz"));
+        Files.createFile(dumpsDir.resolve("raw-wiktextract-data-el-2026-05-31.jsonl.gz"));
+        Files.createFile(dumpsDir.resolve("raw-wiktextract-data-fr-2026-08-12.jsonl.gz"));
+
+        // When
+        Optional<Path> result = CLI.findLatestDump("el", dumpsDir);
+
+        // Then
+        assertThat(result).contains(dumpsDir.resolve("raw-wiktextract-data-el-2026-05-31.jsonl.gz"));
+    }
+
+    @Test
+    void should_find_nothing_when_the_dumps_directory_holds_no_dump_for_the_language(@TempDir Path dumpsDir)
+            throws IOException {
+        // Given
+        Files.createFile(dumpsDir.resolve("raw-wiktextract-data-fr-2026-08-12.jsonl.gz"));
+
+        // When
+        Optional<Path> result = CLI.findLatestDump("el", dumpsDir);
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void should_exit_with_one_when_generate_finds_no_dump(@TempDir Path dumpsDir) {
+        // Given
+        CommandLine unit = new CommandLine(new CLI());
+
+        // When
+        int result = unit.execute("generate", "el", "en", "--dumps-dir", dumpsDir.toString());
+
+        // Then — the missing dump is reported before any kindling-cli resolution is attempted
+        assertThat(result).isEqualTo(1);
+    }
+
+    @Test
+    void should_download_into_the_resolved_dumps_directory_when_download_is_run(@TempDir Path dumpsDir)
+            throws IOException {
+        // Given
+        CommandLine.ParseResult parsed =
+                new CommandLine(new CLI()).parseArgs("download", "fr", "--dumps-dir", dumpsDir.toString());
+        CLI.Download unit = (CLI.Download) parsed.subcommand().commandSpec().userObject();
+        unit.downloaderFactory = downloaderFactory;
+        when(downloaderFactory.create("fr", dumpsDir, ProgressListener.NOOP)).thenReturn(downloader);
+
+        // When
+        int result = unit.call();
+
+        // Then
+        assertThat(result).isZero();
+        verify(downloader).download();
+    }
+
+    @Test
+    void should_exit_with_one_when_the_download_fails() throws IOException {
+        // Given
+        CLI.Download unit = new CLI.Download();
+        when(downloader.download()).thenThrow(new IOException("HTTP 503"));
+
+        // When
+        int result = unit.run(downloader);
+
+        // Then — the README documents this exit code for scripts that chain download into generate
+        assertThat(result).isEqualTo(1);
     }
 }

--- a/src/test/java/edu/self/w2k/CLITest.java
+++ b/src/test/java/edu/self/w2k/CLITest.java
@@ -1,5 +1,9 @@
 package edu.self.w2k;
 
+import java.nio.file.Path;
+import java.util.Optional;
+
+import edu.self.w2k.config.Preferences;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -72,5 +76,73 @@ class CLITest {
         // Then
         String version = result.subcommand().commandSpec().findOption("--kindling-version").getValue();
         assertThat(version).matches("v\\d+\\.\\d+\\.\\d+");
+    }
+
+    @Test
+    void should_download_into_the_preferences_dumps_directory_when_no_override_is_given() {
+        // Given
+        Preferences preferences = new Preferences(Path.of("/prefs/dumps"),
+                                                  Path.of("/prefs/dictionaries"),
+                                                  Optional.empty(),
+                                                  Optional.empty());
+        CommandLine.ParseResult parsed = new CommandLine(new CLI()).parseArgs("download", "fr");
+        CLI.Download unit = (CLI.Download) parsed.subcommand().commandSpec().userObject();
+
+        // When
+        Path result = unit.dumpsDir(preferences);
+
+        // Then — no longer the CWD-relative dumps/ the CLI used before it shared the GUI's locations
+        assertThat(result).isEqualTo(Path.of("/prefs/dumps"));
+    }
+
+    @Test
+    void should_download_into_the_given_directory_when_dumps_dir_is_overridden() {
+        // Given
+        Preferences preferences = new Preferences(Path.of("/prefs/dumps"),
+                                                  Path.of("/prefs/dictionaries"),
+                                                  Optional.empty(),
+                                                  Optional.empty());
+        CommandLine.ParseResult parsed =
+                new CommandLine(new CLI()).parseArgs("download", "fr", "--dumps-dir", "/override/dumps");
+        CLI.Download unit = (CLI.Download) parsed.subcommand().commandSpec().userObject();
+
+        // When
+        Path result = unit.dumpsDir(preferences);
+
+        // Then
+        assertThat(result).isEqualTo(Path.of("/override/dumps"));
+    }
+
+    @Test
+    void should_generate_from_and_into_the_preferences_directories_when_no_override_is_given() {
+        // Given
+        Preferences preferences = new Preferences(Path.of("/prefs/dumps"),
+                                                  Path.of("/prefs/dictionaries"),
+                                                  Optional.empty(),
+                                                  Optional.empty());
+        CommandLine.ParseResult parsed = new CommandLine(new CLI()).parseArgs("generate", "el", "en");
+        CLI.Generate unit = (CLI.Generate) parsed.subcommand().commandSpec().userObject();
+
+        // When / Then
+        assertThat(unit.dumpsDir(preferences)).isEqualTo(Path.of("/prefs/dumps"));
+        assertThat(unit.dictionariesDir(preferences)).isEqualTo(Path.of("/prefs/dictionaries"));
+    }
+
+    @Test
+    void should_generate_from_and_into_the_given_directories_when_both_are_overridden() {
+        // Given
+        Preferences preferences = new Preferences(Path.of("/prefs/dumps"),
+                                                  Path.of("/prefs/dictionaries"),
+                                                  Optional.empty(),
+                                                  Optional.empty());
+        CommandLine.ParseResult parsed = new CommandLine(new CLI())
+                .parseArgs("generate", "el", "en",
+                           "--dumps-dir", "/override/dumps",
+                           "--dictionaries-dir", "/override/dictionaries");
+        CLI.Generate unit = (CLI.Generate) parsed.subcommand().commandSpec().userObject();
+
+        // When / Then
+        assertThat(unit.dumpsDir(preferences)).isEqualTo(Path.of("/override/dumps"));
+        assertThat(unit.dictionariesDir(preferences)).isEqualTo(Path.of("/override/dictionaries"));
     }
 }


### PR DESCRIPTION
## Problem

The two front-ends resolved `dumps/` and `dictionaries/` differently. The GUI took them from `preferences.properties`, defaulting under `~/Documents/wiktionary-to-kindle/`; the CLI hardcoded `Path.of("dumps")` and `Path.of("dictionaries")`, relative to the working directory, and never touched preferences.

So downloading a dump in the desktop app and then running `generate` from a terminal failed with "No dump found", and the reverse left `.mobi` files somewhere the app's Dumps pane could not see. The split was deliberate once — it predates the GUI — but it is a trap now that the desktop app is the primary way people run this.

## Change

Both front-ends load the same preferences file and therefore share one dumps folder and one dictionaries folder.

`--dumps-dir` and `--dictionaries-dir` override the preferences for a single invocation, for scripts that want their own working folders.

`CLI.DUMPS_DIR`, `CLI.DICTIONARIES_DIR` and the `KaikkiDumpDownloader(String)` constructor that hardcoded `Path.of("dumps")` are removed, so nothing can silently fall back to a CWD-relative path again. `CLI.findLatestDump` takes the resolved dumps directory as an argument.

Resolution lives in one place per subcommand — `dumpsDir(Preferences)` and `dictionariesDir(Preferences)` — taking the loaded preferences as an argument rather than calling `Preferences.load()` themselves, so the tests exercise the real picocli-parsed objects without touching the config file on the host.

`Download` obtains its downloader through a `DictionaryPipeline.DownloaderFactory` rather than constructing `KaikkiDumpDownloader` inline, reusing the seam the pipeline already has. That is what makes it testable that the resolved dumps directory is the one actually handed to the downloader.

## Breaking change

`download` and `generate` no longer use `./dumps` and `./dictionaries` by default.

To keep the old behaviour:

```sh
java -jar wiktionary-to-kindle-<version>.jar generate el en --dumps-dir ./dumps --dictionaries-dir ./dictionaries
```

Or move the existing folders into `~/Documents/wiktionary-to-kindle/`.

The commit is marked `!` with a `BREAKING CHANGE:` footer, so git-cliff flags it in the changelog.

## Not changed

Logs, config and the `kindling-cli` cache already follow XDG (`$XDG_STATE_HOME`, `$XDG_CONFIG_HOME`, `$XDG_CACHE_HOME`) and are untouched. Dumps and dictionaries stay under Documents rather than `$XDG_DATA_HOME` for the reason already documented in `AppPaths`: they are multi-gigabyte, and the `.mobi` has to be found and copied to a Kindle.

## Testing

`mvn test` — 246 tests, all passing, 100% line coverage on the new code in `CLI.java`.

Nine new `CLITest` cases: preferences-by-default and override-when-given for both subcommands, `findLatestDump` picking the latest dump and finding none, `generate` exiting 1 when no dump matches, and the download exit codes the README documents (0 on success, 1 on transfer failure) — the latter previously untested.

Docs updated: README "Where files go" and "Command line" (including a migration note), and the architecture notes in `.github/copilot-instructions.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)