### PR TITLE
fix(config): enforce the absolute-path invariant on data directories

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -75,14 +75,12 @@ java -jar target/wiktionary-to-kindle-<version>.jar --version
 
 ### Data Directories
 
-The two front-ends resolve these differently, deliberately.
-
 | Directory | Purpose |
 |-----------|---------|
 | `dumps/`  | Downloaded `raw-wiktextract-data-{lang}-{YYYY-MM-DD}.jsonl.gz` from kaikki.org |
 | `dictionaries/` | Final `.mobi` dictionary files, plus side-artefacts `.opf`, `-N.html`, `-toc.ncx` and `-cover.jpg` |
 
-Both front-ends resolve them the same way: absolute, from `Preferences`, defaulting under `AppPaths.defaultDataDir()` (`~/Documents/wiktionary-to-kindle`). A bundled `.app` launches with `cwd=/`, so relative paths would resolve at the filesystem root — this is not a stylistic choice.
+Both front-ends resolve them the same way: absolute, from `Preferences`, defaulting under `AppPaths.defaultDataDir()` (`~/Documents/wiktionary-to-kindle`). A bundled `.app` launches with `cwd=/`, so relative paths would resolve at the filesystem root — this is not a stylistic choice. The `Preferences` compact constructor enforces it, calling `toAbsolutePath().normalize()` on all three paths, so a relative value from a hand-edited properties file or from text typed into `PreferencesDialog` is resolved once, at the boundary, and never reaches a collaborator. Do not re-normalise downstream, and do not weaken it to a `load()`-only check — the dialog constructs the record directly.
 
 The CLI additionally accepts `--dumps-dir` and `--dictionaries-dir`, overriding the preferences for that invocation. `CLI.Download.dumpsDir(Preferences)` and the matching pair on `CLI.Generate` are the single resolution point, and take the loaded preferences as an argument so they stay testable without touching the real config file. Up to 2.0.3 the CLI was CWD-relative via `CLI.DUMPS_DIR` / `CLI.DICTIONARIES_DIR` and never read preferences; both constants are gone, as is the `KaikkiDumpDownloader(String)` constructor that hardcoded `Path.of("dumps")`.
 
@@ -96,6 +94,8 @@ The CLI additionally accepts `--dumps-dir` and `--dictionaries-dir`, overriding 
 | `defaultDataDir()` | `$XDG_DOCUMENTS_DIR` → `~/Documents` | `%USERPROFILE%\Documents` | `dumps/`, `dictionaries/` |
 
 The data dir is under Documents rather than `$XDG_DATA_HOME` on purpose — see the note above — but resolves that folder the XDG way: the `XDG_DOCUMENTS_DIR` env var, then the same key in `$XDG_CONFIG_HOME/user-dirs.dirs` (a leading `$HOME` is expanded, any parse failure falls through), then `~/Documents`.
+
+A relative value in any of these variables — `HOME` included — is ignored with a warning and treated as unset, as the XDG spec requires. `AppPaths.absolutePath` is the check; it guards the Unix branch only, because `Path.isAbsolute()` answers for the filesystem the JVM runs on and would call a Windows `C:\local` relative on the Linux CI runner. The Windows variables are outside the spec anyway.
 
 ### Dictionary Output Format
 

--- a/src/main/java/edu/self/w2k/config/AppPaths.java
+++ b/src/main/java/edu/self/w2k/config/AppPaths.java
@@ -3,6 +3,7 @@ package edu.self.w2k.config;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.Locale;
 import java.util.Map;
@@ -91,11 +92,8 @@ public final class AppPaths {
         if (isWindows(osName)) {
             return home.resolve("Documents");
         }
-        String fromEnv = env.get(DOCUMENTS_KEY);
-        if (isSet(fromEnv)) {
-            return Path.of(expandHome(fromEnv, home));
-        }
-        return readUserDirs(env, home).orElseGet(() -> home.resolve("Documents"));
+        Optional<Path> fromEnv = absolutePath(DOCUMENTS_KEY, expandHome(env.get(DOCUMENTS_KEY), home));
+        return fromEnv.or(() -> readUserDirs(env, home)).orElseGet(() -> home.resolve("Documents"));
     }
 
     /**
@@ -115,7 +113,7 @@ public final class AppPaths {
                         .map(line -> unquote(line.substring(assignment.length()).strip()))
                         .filter(AppPaths::isSet)
                         .findFirst()
-                        .map(value -> Path.of(expandHome(value, home)));
+                        .flatMap(value -> absolutePath(userDirs.toString(), expandHome(value, home)));
         }
         catch (IOException | RuntimeException e) {
             log.warn("Could not read {}: {}", userDirs, e.getLocalizedMessage());
@@ -132,6 +130,7 @@ public final class AppPaths {
 
     /** {@code user-dirs.dirs} writes paths as {@code "$HOME/Documents"}; nothing else is expanded. */
     private static String expandHome(String value, Path home) {
+        if (!isSet(value)) return value;
         if (value.equals("$HOME")) return home.toString();
         if (value.startsWith("$HOME/")) return home + value.substring("$HOME".length());
         return value;
@@ -146,10 +145,10 @@ public final class AppPaths {
     }
 
     private static Path unixBase(Map<String, String> env, String xdgVar, String... homeFallback) {
-        String xdg = env.get(xdgVar);
-        if (isSet(xdg)) return Path.of(xdg);
-        String home = env.get("HOME");
-        if (isSet(home)) return Path.of(home, homeFallback);
+        Optional<Path> xdg = absolutePath(xdgVar, env.get(xdgVar));
+        if (xdg.isPresent()) return xdg.get();
+        Optional<Path> home = absolutePath("HOME", env.get("HOME"));
+        if (home.isPresent()) return Path.of(home.get().toString(), homeFallback);
         return tmpFallback("HOME not set");
     }
 
@@ -162,9 +161,37 @@ public final class AppPaths {
     }
 
     private static Path homeDir(Map<String, String> env, String osName) {
-        String home = env.get(isWindows(osName) ? "USERPROFILE" : "HOME");
-        if (isSet(home)) return Path.of(home);
-        return tmpFallback("home directory not set");
+        if (isWindows(osName)) {
+            String profile = env.get("USERPROFILE");
+            return isSet(profile) ? Path.of(profile) : tmpFallback("home directory not set");
+        }
+        return absolutePath("HOME", env.get("HOME")).orElseGet(() -> tmpFallback("home directory not set"));
+    }
+
+    /**
+     * The XDG spec requires a relative path in one of its variables to be treated as invalid. Honouring
+     * that keeps a misconfigured environment on the documented default instead of resolving against
+     * whatever the working directory happens to be — which differs between the bundled app and the CLI.
+     * <p>
+     * Only the Unix branch uses this. {@link Path#isAbsolute()} answers for the filesystem the JVM is
+     * running on, so a Windows value such as {@code C:\local} would be judged relative everywhere else,
+     * and the Windows variables are not governed by the XDG spec in any case.
+     */
+    private static Optional<Path> absolutePath(String source, String value) {
+        if (!isSet(value)) {
+            return Optional.empty();
+        }
+        try {
+            Path path = Path.of(value);
+            if (path.isAbsolute()) {
+                return Optional.of(path);
+            }
+            log.warn("Ignoring {}: {} is not an absolute path", source, value);
+        }
+        catch (InvalidPathException e) {
+            log.warn("Ignoring {}: {}", source, e.getLocalizedMessage());
+        }
+        return Optional.empty();
     }
 
     private static boolean isSet(String value) {

--- a/src/main/java/edu/self/w2k/config/Preferences.java
+++ b/src/main/java/edu/self/w2k/config/Preferences.java
@@ -22,6 +22,13 @@ import lombok.extern.slf4j.Slf4j;
  * invalidate the macOS ad-hoc signature. The bundle instead ships
  * {@code -XX:MaxRAMPercentage=75}, which scales with the machine.
  *
+ * Every path is made absolute on construction, wherever it came from — the properties file, the
+ * preferences dialog, or a caller. A relative path would otherwise mean two different directories to
+ * the two front-ends: a bundled {@code .app} launches with the working directory set to {@code /},
+ * while the CLI inherits the shell's. Normalising here rather than at each use keeps the invariant
+ * the rest of the code already assumes, and shows the user the resolved path when the dialog
+ * reopens.
+ *
  * @param dumpsDir        where downloaded kaikki.org dumps are kept
  * @param dictionariesDir where generated dictionaries are written
  * @param kindlingCliPath explicit kindling-cli binary, bypassing PATH/cache/download resolution
@@ -32,6 +39,12 @@ public record Preferences(Path dumpsDir,
                           Path dictionariesDir,
                           Optional<Path> kindlingCliPath,
                           Optional<String> kindlingVersion) {
+
+    public Preferences {
+        dumpsDir = absolute(dumpsDir);
+        dictionariesDir = absolute(dictionariesDir);
+        kindlingCliPath = kindlingCliPath.map(Preferences::absolute);
+    }
 
     static final String FILE_NAME = "preferences.properties";
 
@@ -114,5 +127,9 @@ public record Preferences(Path dumpsDir,
 
     private static Optional<Path> path(Properties props, String key) {
         return value(props, key).map(Path::of);
+    }
+
+    private static Path absolute(Path path) {
+        return path.toAbsolutePath().normalize();
     }
 }

--- a/src/test/java/edu/self/w2k/config/AppPathsTest.java
+++ b/src/test/java/edu/self/w2k/config/AppPathsTest.java
@@ -261,6 +261,79 @@ class AppPathsTest {
     }
 
     @Test
+    void should_ignore_a_relative_xdg_config_home() {
+        // Given the XDG spec calls a relative value invalid, rather than resolving it against the CWD
+        Map<String, String> env = Map.of("XDG_CONFIG_HOME", "relative/config", "HOME", "/h");
+
+        // When
+        Path result = AppPaths.configDir(env, "Linux");
+
+        // Then
+        assertThat(result).isEqualTo(Path.of("/h/.config/wiktionary-to-kindle"));
+    }
+
+    @Test
+    void should_ignore_a_relative_xdg_cache_home() {
+        // Given
+        Map<String, String> env = Map.of("XDG_CACHE_HOME", "relative/cache", "HOME", "/h");
+
+        // When
+        Path result = AppPaths.cacheDir(env, "Linux");
+
+        // Then
+        assertThat(result).isEqualTo(Path.of("/h/.cache/wiktionary-to-kindle"));
+    }
+
+    @Test
+    void should_ignore_a_relative_xdg_state_home() {
+        // Given
+        Map<String, String> env = Map.of("XDG_STATE_HOME", "relative/state", "HOME", "/h");
+
+        // When
+        Path result = AppPaths.stateDir(env, "Linux");
+
+        // Then
+        assertThat(result).isEqualTo(Path.of("/h/.local/state/wiktionary-to-kindle"));
+    }
+
+    @Test
+    void should_ignore_a_relative_xdg_documents_dir() {
+        // Given
+        Map<String, String> env = Map.of("XDG_DOCUMENTS_DIR", "Documenten", "HOME", "/h");
+
+        // When
+        Path result = AppPaths.defaultDataDir(env, "Linux");
+
+        // Then
+        assertThat(result).isEqualTo(Path.of("/h/Documents/wiktionary-to-kindle"));
+    }
+
+    @Test
+    void should_ignore_a_relative_documents_entry_in_user_dirs(@TempDir Path config) throws IOException {
+        // Given a hand-edited user-dirs.dirs whose value is neither absolute nor $HOME-prefixed
+        Files.writeString(config.resolve("user-dirs.dirs"), "XDG_DOCUMENTS_DIR=\"Documenten\"\n");
+        Map<String, String> env = Map.of("XDG_CONFIG_HOME", config.toString(), "HOME", "/h");
+
+        // When
+        Path result = AppPaths.defaultDataDir(env, "Linux");
+
+        // Then
+        assertThat(result).isEqualTo(Path.of("/h/Documents/wiktionary-to-kindle"));
+    }
+
+    @Test
+    void should_ignore_a_relative_home_on_unix() {
+        // Given
+        Map<String, String> env = Map.of("HOME", "relative/home");
+
+        // When
+        Path result = AppPaths.configDir(env, "Linux");
+
+        // Then — the tmpdir fallback, exactly as if HOME had been unset
+        assertThat(result.toString()).startsWith(System.getProperty("java.io.tmpdir"));
+    }
+
+    @Test
     void should_ignore_user_dirs_on_windows() {
         // Given a Windows environment that happens to carry XDG variables, e.g. under Git Bash
         Map<String, String> env = Map.of("XDG_DOCUMENTS_DIR", "/h/Documenten",

--- a/src/test/java/edu/self/w2k/config/AppPathsTest.java
+++ b/src/test/java/edu/self/w2k/config/AppPathsTest.java
@@ -9,6 +9,8 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class AppPathsTest {
 
@@ -48,10 +50,12 @@ class AppPathsTest {
         assertThat(result).isEqualTo(Path.of("/c/wiktionary-to-kindle"));
     }
 
-    @Test
-    void should_ignore_blank_xdg_when_resolving_config_dir() {
-        // Given
-        Map<String, String> env = Map.of("XDG_CONFIG_HOME", "  ", "HOME", "/h");
+    @ParameterizedTest
+    @ValueSource(strings = {"  ", "relative/config"})
+    void should_ignore_an_unusable_xdg_config_home(String value) {
+        // Given blank means unset, and the XDG spec calls a relative value invalid rather than
+        // resolving it against the working directory
+        Map<String, String> env = Map.of("XDG_CONFIG_HOME", value, "HOME", "/h");
 
         // When
         Path result = AppPaths.configDir(env, "Linux");
@@ -258,18 +262,6 @@ class AppPathsTest {
 
         // Then
         assertThat(result).isEqualTo(Path.of("/h/Documents/wiktionary-to-kindle"));
-    }
-
-    @Test
-    void should_ignore_a_relative_xdg_config_home() {
-        // Given the XDG spec calls a relative value invalid, rather than resolving it against the CWD
-        Map<String, String> env = Map.of("XDG_CONFIG_HOME", "relative/config", "HOME", "/h");
-
-        // When
-        Path result = AppPaths.configDir(env, "Linux");
-
-        // Then
-        assertThat(result).isEqualTo(Path.of("/h/.config/wiktionary-to-kindle"));
     }
 
     @Test

--- a/src/test/java/edu/self/w2k/config/PreferencesTest.java
+++ b/src/test/java/edu/self/w2k/config/PreferencesTest.java
@@ -118,6 +118,39 @@ class PreferencesTest {
     }
 
     @Test
+    void should_make_relative_directories_absolute_when_loading() throws Exception {
+        // Given a hand-edited file, which would otherwise mean the filesystem root to the bundled app
+        Path file = tmp.resolve("preferences.properties");
+        Files.writeString(file, """
+                dumpsDir=dumps
+                dictionariesDir=./out/../dictionaries
+                kindlingCliPath=bin/kindling-cli
+                """, StandardCharsets.UTF_8);
+
+        // When
+        Preferences loaded = Preferences.load(file);
+
+        // Then — compared by file name because the directories need not exist, and AssertJ's
+        // Path.endsWith resolves the real path on disk
+        assertThat(loaded.dumpsDir()).isAbsolute().hasFileName("dumps");
+        assertThat(loaded.dictionariesDir()).isAbsolute().hasFileName("dictionaries");
+        assertThat(loaded.kindlingCliPath()).hasValueSatisfying(path -> assertThat(path).isAbsolute());
+    }
+
+    @Test
+    void should_make_relative_directories_absolute_when_constructed_directly() {
+        // Given the preferences dialog hands over whatever text the user typed
+        Preferences unit = new Preferences(Path.of("dumps"),
+                                           Path.of("dictionaries"),
+                                           Optional.empty(),
+                                           Optional.empty());
+
+        // Then
+        assertThat(unit.dumpsDir()).isAbsolute();
+        assertThat(unit.dictionariesDir()).isAbsolute();
+    }
+
+    @Test
     void should_default_dumps_and_dictionaries_under_a_common_parent() {
         // When
         Preferences defaults = Preferences.defaults();


### PR DESCRIPTION
Follow-up to #87, which made both front-ends share one dumps folder and one dictionaries folder. Auditing the result turned up three gaps in the same area.

## 1. "Absolute" was documented, never enforced

`AppPaths` javadoc and the architecture notes both assert these paths are absolute. Nothing checked. `PreferencesDialog` does `Path.of(text.strip())` on typed text and `Preferences.load` does `map(Path::of)` — a relative value survived both.

That meant one preferences file naming two different directories. Reproduced with `dumpsDir=dumps`, before this change:

```
--- relative pref, run from /tmp ---
ERROR - No dump found for language el in dumps
--- relative pref, run from elsewhere ---
ERROR - No dump found for language el in dumps
```

Two different folders, and in a bundled `.app` (cwd=`/`) it becomes `/dumps` — the exact failure the `AppPaths` javadoc warns about. Pre-existing for the GUI; #87 gave it to the CLI too, which is where someone would plausibly type a relative path.

Fixed in the `Preferences` compact constructor, which every instance passes through — including the ones the dialog builds, so a `load()`-only check would not have covered it. After:

```
--- relative pref, run from /tmp ---
ERROR - No dump found for language el in /private/tmp/dumps
```

The resolved path is what gets stored and what the dialog shows on reopen, instead of being re-derived per run.

## 2. Relative XDG values were honoured

The XDG spec requires a relative path in one of its variables to be treated as invalid. `AppPaths` accepted them, resolving against the working directory — the same divergence as above, one level up. Now ignored with a warning, falling back as if unset:

```
WARN  - Ignoring XDG_CONFIG_HOME: relative/config is not an absolute path
ERROR - No dump found for language el in /Users/…/Documents/wiktionary-to-kindle/dumps
```

Covers `XDG_CONFIG_HOME`, `XDG_CACHE_HOME`, `XDG_STATE_HOME`, `XDG_DOCUMENTS_DIR`, the `user-dirs.dirs` entry and `HOME`.

The check deliberately guards the Unix branch only. `Path.isAbsolute()` answers for the filesystem the JVM is running on, so a Windows `C:\local` reads as relative on the Linux CI runner and would have sent the existing Windows tests to the tmpdir fallback. The Windows variables are not governed by the XDG spec anyway.

## 3. Stale line in the architecture notes

`.github/copilot-instructions.md` still opened the Data Directories section with "The two front-ends resolve these differently, deliberately", two paragraphs above the text saying they resolve identically. #87 replaced the bullets under it and left the lead-in. Removed, and the enforcement points are now documented where the invariant is stated.

## Testing

`mvn test` — 317 tests, all passing.

Eight new cases: relative `XDG_CONFIG_HOME` / `XDG_CACHE_HOME` / `XDG_STATE_HOME` / `XDG_DOCUMENTS_DIR` / `user-dirs.dirs` entry / `HOME` each ignored, and `Preferences` making relative paths absolute both when loaded from a file and when constructed directly the way the dialog does it.

The two shell transcripts above are from the built jar on this branch, driven with `XDG_CONFIG_HOME` pointed at a scratch config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)