### PR TITLE
refactor: clear the low-effort sonar findings

### DIFF
--- a/.github/workflows/java-ci.yaml
+++ b/.github/workflows/java-ci.yaml
@@ -9,12 +9,14 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
-  statuses: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: write
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
+  contents: read
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Job 1: bump the pom version, update the changelog, commit, tag and push
@@ -248,6 +248,8 @@ jobs:
   release:
     needs: [prepare, build]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       VERSION: ${{ needs.prepare.outputs.release_version }}
     steps:

--- a/src/main/java/edu/self/w2k/CLI.java
+++ b/src/main/java/edu/self/w2k/CLI.java
@@ -69,7 +69,7 @@ public class CLI implements Callable<Integer> {
 
     @Override
     public Integer call() {
-        spec.commandLine().usage(System.out);
+        spec.commandLine().usage(spec.commandLine().getOut());
         return 0;
     }
 

--- a/src/main/java/edu/self/w2k/gui/ProgressSnapshot.java
+++ b/src/main/java/edu/self/w2k/gui/ProgressSnapshot.java
@@ -60,7 +60,7 @@ public record ProgressSnapshot(double fraction, String message) {
     }
 
     /** True when the total was reported as {@link ProgressListener#TOTAL_UNKNOWN}. */
-    public boolean indeterminate() {
+    public boolean isIndeterminate() {
         return fraction == INDETERMINATE;
     }
 }

--- a/src/main/java/edu/self/w2k/progress/CountingInputStream.java
+++ b/src/main/java/edu/self/w2k/progress/CountingInputStream.java
@@ -29,10 +29,10 @@ public final class CountingInputStream extends FilterInputStream {
      * @param reporter    receives the cumulative byte count
      */
     public CountingInputStream(InputStream in, long reportEvery, LongConsumer reporter) {
-        super(in);
         if (reportEvery <= 0) {
             throw new IllegalArgumentException("reportEvery must be positive, got " + reportEvery);
         }
+        super(in);
         this.reportEvery = reportEvery;
         this.reporter = reporter;
     }

--- a/src/main/java/edu/self/w2k/render/HtmlDefinitionRenderer.java
+++ b/src/main/java/edu/self/w2k/render/HtmlDefinitionRenderer.java
@@ -20,6 +20,8 @@ public class HtmlDefinitionRenderer implements DefinitionRenderer {
 
     private static final int VISIBLE_FORMS_THRESHOLD = 30;
 
+    private static final String LIST_ITEM_END = "</li>";
+
     @Override
     public Optional<RenderedEntry> render(WiktionaryEntry entry) {
         StringBuilder sb = new StringBuilder();
@@ -124,14 +126,14 @@ public class HtmlDefinitionRenderer implements DefinitionRenderer {
                     hasExample = true;
                     exSb.append("<li>");
                     exSb.append(StringEscapeUtils.escapeXml10(text.replaceAll("[\n\r]", "; ")));
-                    exSb.append("</li>");
+                    exSb.append(LIST_ITEM_END);
                 }
                 exSb.append("</ul>");
                 if (hasExample) {
                     sb.append(exSb);
                 }
 
-                sb.append("</li>");
+                sb.append(LIST_ITEM_END);
             }
         }
 
@@ -161,7 +163,7 @@ public class HtmlDefinitionRenderer implements DefinitionRenderer {
         if (filtered.isEmpty()) {
             return List.of();
         }
-        Set<String> seen = new LinkedHashSet<>(filtered.size());
+        Set<String> seen = LinkedHashSet.newLinkedHashSet(filtered.size());
         for (WiktionaryForm form : filtered) {
             String text = form.form().strip();
             if (isUsableLookupKey(text)) {
@@ -213,7 +215,7 @@ public class HtmlDefinitionRenderer implements DefinitionRenderer {
                 sb.append(' ');
             }
             sb.append(StringEscapeUtils.escapeXml10(form.form().strip()));
-            sb.append("</li>");
+            sb.append(LIST_ITEM_END);
         }
         sb.append("</ul>");
     }

--- a/src/test/java/edu/self/w2k/config/PreferencesTest.java
+++ b/src/test/java/edu/self/w2k/config/PreferencesTest.java
@@ -205,7 +205,7 @@ class PreferencesTest {
         Preferences defaults = Preferences.defaults();
 
         // Then
-        assertThat(defaults.dumpsDir().getParent()).isEqualTo(defaults.dictionariesDir().getParent());
+        assertThat(defaults.dumpsDir()).hasParentRaw(defaults.dictionariesDir().getParent());
         assertThat(defaults.dumpsDir().getFileName()).hasToString("dumps");
         assertThat(defaults.dictionariesDir().getFileName()).hasToString("dictionaries");
     }

--- a/src/test/java/edu/self/w2k/gui/MainFxmlLoadTest.java
+++ b/src/test/java/edu/self/w2k/gui/MainFxmlLoadTest.java
@@ -85,7 +85,7 @@ class MainFxmlLoadTest {
             }
             toolkitReady = false;
         }
-        catch (Error e) {
+        catch (Error _) {
             // No display, or the native libraries cannot initialise.
             toolkitReady = false;
         }

--- a/src/test/java/edu/self/w2k/gui/PipelineTaskTest.java
+++ b/src/test/java/edu/self/w2k/gui/PipelineTaskTest.java
@@ -1,6 +1,7 @@
 package edu.self.w2k.gui;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -74,7 +75,7 @@ class PipelineTaskTest {
         PipelineTask task = new PipelineTask(pipeline, PREFS, "el", "en", ProgressListener.NOOP);
 
         // When / Then — cancelling during download must not blow up on a null process
-        task.terminateKindling();
+        assertThatCode(task::terminateKindling).doesNotThrowAnyException();
     }
 
     @Test
@@ -113,7 +114,7 @@ class PipelineTaskTest {
     }
 
     @Test
-    void should_use_the_view_models_selection_when_creating_a_task() {
+    void should_use_the_view_models_selection_when_creating_a_task() throws Exception {
         // Given
         MainViewModel viewModel = new MainViewModel();
         viewModel.preferencesProperty().set(PREFS);
@@ -137,5 +138,7 @@ class PipelineTaskTest {
 
         // Then
         assertThat(task).isInstanceOf(PipelineTask.class);
+        assertThat(((PipelineTask) task).call()).isEqualTo(MOBI);
+        assertThat(seen).containsExactly("el", "en");
     }
 }

--- a/src/test/java/edu/self/w2k/gui/ProgressSnapshotTest.java
+++ b/src/test/java/edu/self/w2k/gui/ProgressSnapshotTest.java
@@ -30,7 +30,7 @@ class ProgressSnapshotTest {
                 ProgressSnapshot.of(Stage.DOWNLOAD, 7 * MB, ProgressListener.TOTAL_UNKNOWN);
 
         // Then
-        assertThat(snapshot.indeterminate()).isTrue();
+        assertThat(snapshot.isIndeterminate()).isTrue();
         assertThat(snapshot.fraction()).isEqualTo(ProgressSnapshot.INDETERMINATE);
         assertThat(snapshot.message()).isEqualTo("Downloading dump… 7 MB");
     }
@@ -60,7 +60,7 @@ class ProgressSnapshotTest {
         ProgressSnapshot snapshot = ProgressSnapshot.of(Stage.FOLD, 0, ProgressListener.TOTAL_UNKNOWN);
 
         // Then
-        assertThat(snapshot.indeterminate()).isTrue();
+        assertThat(snapshot.isIndeterminate()).isTrue();
         assertThat(snapshot.message()).isEqualTo("Folding inflected forms…");
     }
 
@@ -70,7 +70,7 @@ class ProgressSnapshotTest {
         ProgressSnapshot snapshot = ProgressSnapshot.of(Stage.KINDLING, 0, ProgressListener.TOTAL_UNKNOWN);
 
         // Then
-        assertThat(snapshot.indeterminate()).isTrue();
+        assertThat(snapshot.isIndeterminate()).isTrue();
         assertThat(snapshot.message()).contains("kindling-cli");
     }
 
@@ -100,7 +100,7 @@ class ProgressSnapshotTest {
 
         // Then
         assertThat(idle.fraction()).isZero();
-        assertThat(idle.indeterminate()).isFalse();
+        assertThat(idle.isIndeterminate()).isFalse();
         assertThat(idle.message()).isEqualTo("Ready");
     }
 }

--- a/src/test/java/edu/self/w2k/pipeline/DictionaryPipelineTest.java
+++ b/src/test/java/edu/self/w2k/pipeline/DictionaryPipelineTest.java
@@ -104,7 +104,7 @@ class DictionaryPipelineTest {
     }
 
     @Test
-    void should_not_generate_when_the_download_fails() throws Exception {
+    void should_not_generate_when_the_download_fails() {
         // Given
         AtomicReference<Boolean> generated = new AtomicReference<>(false);
         DictionaryPipeline unit = new DictionaryPipeline(

--- a/src/test/java/edu/self/w2k/write/opf/HtmlChapterRendererTest.java
+++ b/src/test/java/edu/self/w2k/write/opf/HtmlChapterRendererTest.java
@@ -72,11 +72,11 @@ class HtmlChapterRendererTest {
                 .contains("<idx:orth value=\"σύντροφος\"><b>σύντροφος</b></idx:orth>")
                 .contains("<idx:infl><idx:iform value=\"σύντροφοι\"/>")
                 .contains("<idx:iform value=\"συντρόφου\"/>")
-                .contains("<idx:iform value=\"συντρόφους\"/></idx:infl>");
-        // <idx:infl> must be a sibling of <idx:orth>, never a child (mixed content
-        // inside <idx:orth> crashes the Kindle popup renderer on long-press)
-        assertThat(html).doesNotContain("<idx:orth value=\"σύντροφος\"><idx:infl");
-        assertThat(html).doesNotContain("</idx:infl></idx:orth>");
+                .contains("<idx:iform value=\"συντρόφους\"/></idx:infl>")
+                // <idx:infl> must be a sibling of <idx:orth>, never a child (mixed content
+                // inside <idx:orth> crashes the Kindle popup renderer on long-press)
+                .doesNotContain("<idx:orth value=\"σύντροφος\"><idx:infl")
+                .doesNotContain("</idx:infl></idx:orth>");
     }
 
     @Test


### PR DESCRIPTION
Thirteen of the twenty-one open SonarCloud issues, picked for having a fix that is obviously correct rather than a judgement call. `mvn verify` is green; the diff changes no behaviour.

## Workflow permissions (3 × `githubactions:S8233`)

The only findings with teeth. Both workflows granted their write scopes at workflow level, so every job carried them. `pull-requests: write` and `statuses: write` exist for Sonar's PR decoration and belong to `build` alone; `contents: write` exists for `gh release create` and belongs to `release` alone. The `prepare` job pushes the release commit and tag over a remote authenticated with `RELEASE_TOKEN`, so it never used the workflow token's write scope in the first place — narrowing it costs nothing there.

## Main code

- `java:S1845` — `ProgressSnapshot.indeterminate()` reads as an accessor for the `INDETERMINATE` constant declared next to it, which it is not. Renamed to `isIndeterminate()`.
- `java:S8433` — `CountingInputStream` validated `reportEvery` after `super(in)`, so a bad argument wrapped the stream before throwing. Java 25's flexible constructor bodies let the check come first.
- `java:S1192` / `java:S6485` — a `LIST_ITEM_END` constant for the tripled `"</li>"`, and `LinkedHashSet.newLinkedHashSet(size)` instead of the constructor, whose argument is a capacity rather than an element count.
- `java:S106` — `CLI` printed its usage to `System.out` directly. It now uses picocli's own writer, which defaults to the same stream, so output is unchanged. A logger would have been the wrong fix for a CLI's help text.

## Tests

Assertion hygiene throughout — unnamed `catch (Error _)`, `assertThatCode(...).doesNotThrowAnyException()` for the test that had none, an unnecessary `throws Exception` dropped, `hasParentRaw`, two stray `doesNotContain` calls folded into the chain above them.

One is more than hygiene. `should_use_the_view_models_selection_when_creating_a_task` collected the edition and word language the pipeline was called with, then asserted only that a task had been created — Sonar flagged the collection as unused, and it was, so the test never checked the thing it is named for. It now runs the task and asserts on what was collected.

## Deliberately left

The remaining eight are refactors, not quick wins: two `S107` constructor-arity findings on `GenerateCommand` (wants a parameter object), and four findings over `HtmlDefinitionRenderer.appendDefinitions` — three `S135` and one `S3776` that are all the same nested-loop knot and want extracting, not patching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)