### PR TITLE
fix(dumps): stop warning about the dumps folder on first start

### DIFF
--- a/src/main/java/edu/self/w2k/dump/DumpCatalog.java
+++ b/src/main/java/edu/self/w2k/dump/DumpCatalog.java
@@ -2,7 +2,9 @@ package edu.self.w2k.dump;
 
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
+import java.nio.file.FileSystemException;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -42,8 +44,12 @@ public class DumpCatalog {
                                          () -> log.debug("Ignoring unrecognised dump filename: {}", path));
             }
         }
+        catch (NoSuchFileException _) {
+            log.debug("No dumps directory yet at {}", dumpsDir);
+            return List.of();
+        }
         catch (IOException e) {
-            log.warn("Could not list dumps in {}: {}", dumpsDir, e.getLocalizedMessage());
+            log.warn("Could not list dumps in {}: {}", dumpsDir, describe(e));
             return List.of();
         }
 
@@ -88,6 +94,15 @@ public class DumpCatalog {
             log.info("Deleted dump {}", dump.path());
         }
         return deleted;
+    }
+
+    private static String describe(IOException e) {
+        if (e instanceof FileSystemException fileSystemException) {
+            return fileSystemException.getReason() != null
+                    ? fileSystemException.getReason()
+                    : e.getClass().getSimpleName();
+        }
+        return e.getLocalizedMessage();
     }
 
     private static long sizeOf(Path path) {

--- a/src/test/java/edu/self/w2k/dump/DumpCatalogTest.java
+++ b/src/test/java/edu/self/w2k/dump/DumpCatalogTest.java
@@ -4,13 +4,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.NotDirectoryException;
 import java.nio.file.Path;
 import java.time.LocalDate;
 import java.util.Optional;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.LoggerFactory;
 
 class DumpCatalogTest {
 
@@ -18,10 +24,19 @@ class DumpCatalogTest {
     Path tmp;
 
     private DumpCatalog unit;
+    private ListAppender<ILoggingEvent> logged;
 
     @BeforeEach
     void setUp() {
         unit = new DumpCatalog(tmp);
+        logged = new ListAppender<>();
+        logged.start();
+        logger().addAppender(logged);
+    }
+
+    @AfterEach
+    void tearDown() {
+        logger().detachAppender(logged);
     }
 
     @Test
@@ -79,6 +94,40 @@ class DumpCatalogTest {
         // When / Then
         assertThat(absent.list()).isEmpty();
         assertThat(absent.latestFor("el")).isEmpty();
+    }
+
+    @Test
+    void should_stay_quiet_when_dumps_dir_does_not_exist() {
+        // Given a first run: the dumps folder is created by the first download, not before it
+        DumpCatalog absent = new DumpCatalog(tmp.resolve("nope"));
+
+        // When
+        absent.list();
+
+        // Then
+        assertThat(logged.list).noneMatch(event -> event.getLevel().isGreaterOrEqual(Level.WARN));
+    }
+
+    @Test
+    void should_name_the_cause_rather_than_the_path_when_the_dumps_dir_is_not_a_directory()
+            throws Exception {
+        // Given
+        Path file = tmp.resolve("not-a-directory");
+        Files.createFile(file);
+        DumpCatalog unusable = new DumpCatalog(file);
+
+        // When
+        assertThat(unusable.list()).isEmpty();
+
+        // Then the path is named once, by the template, and the cause explains the failure
+        assertThat(logged.list).singleElement()
+                .satisfies(event -> {
+                    assertThat(event.getLevel()).isEqualTo(Level.WARN);
+                    assertThat(event.getFormattedMessage())
+                            .contains(NotDirectoryException.class.getSimpleName())
+                            .satisfies(message -> assertThat(occurrencesOf(file.toString(), message))
+                                    .isEqualTo(1));
+                });
     }
 
     @Test
@@ -156,6 +205,18 @@ class DumpCatalogTest {
         Path path = tmp.resolve("raw-wiktextract-data-%s-%s.jsonl.gz".formatted(lang, date));
         Files.createFile(path);
         return path;
+    }
+
+    private static int occurrencesOf(String needle, String haystack) {
+        int count = 0;
+        for (int at = haystack.indexOf(needle); at >= 0; at = haystack.indexOf(needle, at + 1)) {
+            count++;
+        }
+        return count;
+    }
+
+    private static ch.qos.logback.classic.Logger logger() {
+        return (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(DumpCatalog.class);
     }
 
     private static org.assertj.core.groups.Tuple tuple(String lang, String date) {


### PR DESCRIPTION
Closes #92.

## What the user saw

```
10:09:27 WARN  - Could not list dumps in C:\Users\xx\Documents\wiktionary-to-kindle\dumps: C:\Users\xx\Documents\wiktionary-to-kindle\dumps
```

Two defects in one line.

**The path is printed twice.** `Files.newDirectoryStream` on a missing directory throws `NoSuchFileException`, and `FileSystemException.getMessage()` is the failing file plus an optional reason. `NoSuchFileException` carries no reason, so the message *is* the path — which the log template had already named. The "cause" half of the line said nothing the first half had not.

**It is a warning about the normal first-run state.** The dumps folder is created by the first download, so on a fresh install it is simply not there yet. `MainController.dumpsPlaceholder` already tells the user this in the table, in words that say what happens next; the log line only added noise, at a level the console pane surfaces. `refreshDumps()` runs once at startup, so the line appeared once — the duplication was inside it.

## The fix

`DumpCatalog.list()` splits the catch: `NoSuchFileException` is a debug line, everything else still warns but goes through `describe`, which prefers `FileSystemException.getReason()` and falls back to the exception type. A real failure now reads `Could not list dumps in C:\…\dumps: AccessDeniedException` — path once, cause named.

Caught rather than pre-checked with `Files.notExists`: it closes the TOCTOU window between check and open (a folder deleted between two refreshes), and it saves a stat on every refresh. This mirrors `Preferences.load`, where a missing file is a silent default and an unreadable one is a warning.

## Tests

Two added to `DumpCatalogTest`, both against a logback `ListAppender`:

- a missing dumps directory logs nothing at WARN or above — the actual regression, and nothing else locked it;
- a dumps directory that is a regular file warns with `NotDirectoryException` named and the path appearing exactly once.

Full suite: 364 tests, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
